### PR TITLE
Map function types to names and update output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ To generate stable MIR output without building a binary, you can invoke the tool
 ./run.sh -Z no-codegen <crate_root>
 ```
 
+There are a few environment variables that can be set to control the tools output:
+
+1.  `LINK_ITEMS` - add entries to the link-time `functions` map for each monomorphic item in the crate;
+2.  `LINK_INST`  - use a richer key-structure for the link-time `functions` map which uses keys that are pairs of a function type (`Ty`) _and_ an function instance kind (`InstanceKind`)
+3.  `DEBUG` - serialize additional data in the JSON file and dump logs to stdout
+
 ### Invocation Details
 
 We use an uncommon build process where we link against a patched rustc installed in this repo.

--- a/src/kani_lib/kani_collector.rs
+++ b/src/kani_lib/kani_collector.rs
@@ -23,6 +23,33 @@ use stable_mir::ty::{RigidTy, ClosureKind, ConstantKind, Allocation, Ty as TySta
 use stable_mir::mir::alloc::{AllocId, GlobalAlloc};
 use stable_mir::Symbol;
 
+/// Collect all (top-level) items in the crate that matches the given predicate.
+/// An item can only be a root if they are a non-generic function.
+pub fn filter_crate_items<F>(tcx: TyCtxt, predicate: F) -> Vec<Instance>
+where
+    F: Fn(TyCtxt, Instance) -> bool,
+{
+    let crate_items = stable_mir::all_local_items();
+    // Filter regular items.
+    crate_items
+        .iter()
+        .filter_map(|item| {
+            // Only collect monomorphic items.
+            // TODO: Remove the def_kind check once https://github.com/rust-lang/rust/pull/119135 has been released.
+            let def_id = rustc_internal::internal(tcx, item.def_id());
+            (matches!(tcx.def_kind(def_id), rustc_hir::def::DefKind::Ctor(..))
+                || matches!(item.kind(), ItemKind::Fn))
+            .then(|| {
+                Instance::try_from(*item)
+                    .ok()
+                    .and_then(|instance| predicate(tcx, instance).then_some(instance))
+            })
+            .flatten()
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Collect all MonoItems that are possibly called by or loaded by an initial list of MonoItems
 pub fn collect_all_mono_items(tcx: TyCtxt, initial_mono_items: &[MonoItem]) -> Vec<MonoItem> {
   let mut collector = MonoItemsCollector::new(tcx);
   for item in initial_mono_items {
@@ -37,6 +64,7 @@ pub fn collect_all_mono_items(tcx: TyCtxt, initial_mono_items: &[MonoItem]) -> V
   sorted_items.sort_by_cached_key(|item| to_fingerprint(tcx, item));
   sorted_items
 }
+
 
 struct MonoItemsCollector<'tcx> {
   /// The compiler context.
@@ -383,32 +411,6 @@ fn collect_alloc_items(alloc_id: AllocId) -> Vec<MonoItem> {
       }
   };
   items
-}
-
-/// Collect all (top-level) items in the crate that matches the given predicate.
-/// An item can only be a root if they are a non-generic function.
-pub fn filter_crate_items<F>(tcx: TyCtxt, predicate: F) -> Vec<Instance>
-where
-    F: Fn(TyCtxt, Instance) -> bool,
-{
-    let crate_items = stable_mir::all_local_items();
-    // Filter regular items.
-    crate_items
-        .iter()
-        .filter_map(|item| {
-            // Only collect monomorphic items.
-            // TODO: Remove the def_kind check once https://github.com/rust-lang/rust/pull/119135 has been released.
-            let def_id = rustc_internal::internal(tcx, item.def_id());
-            (matches!(tcx.def_kind(def_id), rustc_hir::def::DefKind::Ctor(..))
-                || matches!(item.kind(), ItemKind::Fn))
-            .then(|| {
-                Instance::try_from(*item)
-                    .ok()
-                    .and_then(|instance| predicate(tcx, instance).then_some(instance))
-            })
-            .flatten()
-        })
-        .collect::<Vec<_>>()
 }
 
 pub fn extract_unsize_casting<'tcx>(

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -264,16 +264,6 @@ fn fn_inst_sym<'tcx>(tcx: TyCtxt<'tcx>, inst: Option<&Instance>) -> Option<FnSym
   }).flatten()
 }
 
-#[derive(Eq, PartialEq, Debug, Serialize)]
-struct GenericArgsWrapper(stable_mir::ty::GenericArgs);
-impl std::hash::Hash for GenericArgsWrapper {
-    fn hash<H>(&self, state: &mut H) where H: std::hash::Hasher {
-      let bytes_str = format!("{:?}", self);
-      let bytes = bytes_str.as_bytes();
-      bytes.iter().for_each(|byte| state.write_u8(*byte));
-    }
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 enum MaybeInstanceKind<'tcx> {
   MaybeInstance(middle::ty::InstanceKind<'tcx>),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -13,7 +13,7 @@ extern crate serde_json;
 use rustc_middle as middle;
 use rustc_middle::ty::{TyCtxt, Ty, TyKind, EarlyBinder, FnSig, GenericArgs, TypeFoldable, ParamEnv}; // Binder, Generics, GenericPredicates
 use rustc_session::config::{OutFileName, OutputType};
-use rustc_span::{def_id::DefId, symbol}; // symbol::sym::test;
+use rustc_span::{def_id::DefId, symbol, DUMMY_SP}; // symbol::sym::test;
 use rustc_smir::rustc_internal;
 use stable_mir::{CrateItem,CrateDef,ItemKind,mir::{Body,TerminatorKind,Operand},ty::{Allocation,ForeignItemKind},mir::mono::{MonoItem,Instance,InstanceKind},visited_tys,visited_alloc_ids}; // Symbol
 use tracing::enabled;
@@ -243,7 +243,7 @@ fn handle_call(tcx: TyCtxt<'_>, kind: &stable_mir::ty::ConstantKind, ty: &stable
         middle::ty::TyKind::FnDef(def, args) => (def, args),
         _ => panic!("rustc_internal(FnDef) did not return FnDef")
       };
-      let inst = middle::ty::Instance::expect_resolve(tcx, ParamEnv::reveal_all(), def, args).polymorphize(tcx);
+      let inst = middle::ty::Instance::expect_resolve(tcx, ParamEnv::reveal_all(), def, args, DUMMY_SP).polymorphize(tcx);
       match inst.def {
         DropGlue(_, None) | AsyncDropGlueCtorShim(_, None) => {}
         Intrinsic(_) => handle_intrinsic(tcx, inst),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -350,14 +350,20 @@ fn emit_smir_internal(tcx: TyCtxt<'_>, writer: &mut dyn io::Write) {
         }).collect::<Vec<_>>()
       )
   }).collect();
-  write!(writer, "{{\"name\": {}, \"items\": {}, \"allocs\": {}, \"types\": {}, \"functions\": {}, \"foreign_modules\": {}}}",
+  write!(writer, "{{\"name\": {}, \"items\": {}, \"allocs\": {},  \"functions\": {}",
     serde_json::to_string(&local_crate.name).expect("serde_json string failed"),
     serde_json::to_string(&items).expect("serde_json mono items failed"),
     serde_json::to_string(&visited_alloc_ids()).expect("serde_json global allocs failed"),
-    serde_json::to_string(&visited_tys()).expect("serde_json tys failed"),
     serde_json::to_string(&called_functions).expect("serde_json functions failed"),
-    serde_json::to_string(&foreign_modules).expect("foreign_module serialization failed"),
   ).expect("Failed to write JSON to file");
+  if enabled!(tracing::Level::DEBUG) {
+    write!(writer, ",\"types\": {}, \"foreign_modules\": {}}}",
+      serde_json::to_string(&visited_tys()).expect("serde_json tys failed"),
+      serde_json::to_string(&foreign_modules).expect("foreign_module serialization failed"),
+    ).expect("Failed to write JSON to file");
+  } else {
+    write!(writer, "}}").expect("Failed to write JSON to file");
+  }
 }
 
 pub fn emit_smir(tcx: TyCtxt<'_>) {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -293,9 +293,11 @@ fn update_link_map(link_map: &mut std::collections::HashMap<(FnDef, u64), String
     if old_name != name {
       panic!("Checking collisions: {}, Added inconsistent entries into link map! {:?} -> {}, {}", check_collision, (fn_def, &args.0), old_name, name);
     }
-  }
-  if check_collision {
-    println!("Regenerated link map entry: {:?} -> {}", (fn_def, &args.0), name);
+    if check_collision {
+      println!("Regenerated link map entry: {:?} -> {}", (fn_def, &args.0), name);
+    }
+  } else if check_collision {
+    println!("Generated link map entry from call: {:?} -> {}", (fn_def, &args.0), name);
   }
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -337,9 +337,11 @@ impl MirVisitor for LinkNameCollector<'_, '_> {
 
 fn collect_fn_calls(tcx: TyCtxt<'_>, items: Vec<MonoItem>) -> Vec<((stable_mir::ty::Ty, InstanceKindS<'_>), String)> {
   let mut hash_map = HashMap::new();
-  for item in items.iter() {
-    if let MonoItem::Fn ( inst ) = item {
-       update_link_map(&mut hash_map, fn_inst_sym(tcx, Some(inst)), false)
+  if std::env::var("LINK_MONO_ITEMS").is_ok() {
+    for item in items.iter() {
+      if let MonoItem::Fn ( inst ) = item {
+         update_link_map(&mut hash_map, fn_inst_sym(tcx, Some(inst)), false)
+      }
     }
   }
   for item in items.iter() {


### PR DESCRIPTION
This PR makes a series of changes:

1.  the biggest one --- a new top-level field `functions` is added that points to a map from interned `Ty`s (numbers) to link-time function symbol names (strings)
2.  the structure of `MonoItemFn`s changed as follows:
    -   several debug fields were removed and put in the `ItemDetails` struct instead
    -   the `body` and `promoted` array were unified into a single array field
3.  the `MirBody` struct was removed and the `BodyDetails` struct was moved to a new array field in `ItemDetails`
4.  some new env vars were added to control how the link map is built and how debug information is emitted

The construction of the linking map is done in two phases:

-   (optionally) each `MonoItem::Fn(Instance)` has its `Instance`s underlying function type mapped to the `Instance`s link-time mangled name
-   for each `MonoItem::Fn(Instance)`, we walk over its body and any promoted bodies, find each `Call` terminator/`ReifyFnPointer` cast, and then map the corresponding `Instance` type for the `Call` or `fn` pointer cast to its link-time mangled `Instance` name