### PR TITLE
Fix bugs in item collection

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -159,7 +159,11 @@ pub fn has_attr(tcx: TyCtxt<'_>, item: &stable_mir::CrateItem, attr: symbol::Sym
 }
 
 fn mono_item_name(tcx: TyCtxt<'_>, item: &MonoItem) -> String {
-  mono_item_name_int(tcx, &rustc_internal::internal(tcx, item))
+  if let MonoItem::GlobalAsm(data) = item {
+    hash(data).to_string()
+  } else {
+    mono_item_name_int(tcx, &rustc_internal::internal(tcx, item))
+  }
 }
 
 fn mono_item_name_int<'a>(tcx: TyCtxt<'a>, item: &rustc_middle::mir::mono::MonoItem<'a>) -> String {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -464,8 +464,8 @@ impl MirVisitor for UnevaluatedConstCollector<'_,'_> {
       let internal_mono_item = rustc_middle::mir::mono::MonoItem::Fn(inst);
       let item_name = mono_item_name_int(self.tcx, &internal_mono_item);
       if ! (    self.processed_items.contains_key(&item_name)
-             && self.pending_items.contains_key(&item_name)
-             && self.current_item == hash(&item_name)
+             || self.pending_items.contains_key(&item_name)
+             || self.current_item == hash(&item_name)
            )
       {
           if debug_enabled() { println!("Adding unevaluated const body for: {}", item_name); }


### PR DESCRIPTION
This update fixes three issues in three commits:

1.  it fixes an infinite loop condition when doing link map construction
2.  it fixes an issue where a crash would occur when we tried to lookup the name of `GlobalAsm` mono items;
3.  it fixes a crash when building the link map for the standard library using `cargo build -Zbuild-std` where calling `inst.ty()` failed in a case when the underlying function type was already known