### PR TITLE
HOTFIX: use `SEP` variable for `LD_LIBRARY_PATH` modification in run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ STAGE=$(cat "${RUST_DIR}/stage")
 RUST_BUILD_DIR=${RUST_DIR}/src/build/${ARCH}
 SEP=""
 [ -n "${LD_LIBRARY_PATH:-}" ] && SEP=":"
-export LD_LIBRARY_PATH="${RUST_BUILD_DIR}/stage${STAGE}/lib/rustlib/x86_64-unknown-linux-gnu/lib:$SEP${LD_LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="${RUST_BUILD_DIR}/stage${STAGE}/lib/rustlib/x86_64-unknown-linux-gnu/lib$SEP${LD_LIBRARY_PATH:-}"
 if [ -x "$SCRIPT_DIR/target/debug/$BIN" ]; then
   "$SCRIPT_DIR/target/debug/$BIN"   "$@"
 elif [ -x "$SCRIPT_DIR/target/release/$BIN" ]; then


### PR DESCRIPTION
Removes erroneous ":" from `:D_LIBRARY_PATH`