### PR TITLE
Filter and normalise json output for golden test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ TESTDIR=$(CURDIR)/tests/integration/programs
 .PHONY: integration-test
 integration-test: TESTS     ?= $(shell find $(TESTDIR) -type f -name "*.rs")
 integration-test: SMIR      ?= $(CURDIR)/run.sh -Z no-codegen
+# before comparison we want to clean the files up
+integration-test: PRE_FILTER ?= jq -e -f $(TESTDIR)/../pre-filter.jq
 # override this to tweak how expectations are formatted
 integration-test: NORMALIZE ?= jq -S -e -f $(TESTDIR)/../normalise-filter.jq
 # override this to re-make golden files
@@ -115,13 +117,15 @@ integration-test: build
 	for rust in ${TESTS}; do \
 		target=$${rust%.rs}.smir.json; \
 		dir=$$(dirname $${rust}); \
+		${PRE_FILTER} $${target}.expected > temp.json; \
 		echo "$$rust"; \
 		${SMIR} --out-dir $${dir} $${rust} || report "$$rust" "Conversion failed"; \
 		[ -f $${target} ] \
-			&& ${NORMALIZE} $${target} ${DIFF} $${target}.expected \
+			&& ${PRE_FILTER} $${target} | ${NORMALIZE} ${DIFF} temp.json \
 			&& rm $${target} \
 			|| report "$$rust" "Unexpected json output"; \
 		done; \
+		rm -rf temp.json;
 	[ -z "$$errors" ] || (echo "===============\nFAILING TESTS:$$errors"; exit 1)
 
 

--- a/tests/integration/failing/array.smir.json.expected
+++ b/tests/integration/failing/array.smir.json.expected
@@ -84,25 +84,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h38463d653158c251E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h3e77209299d57694E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hedc2c4b05a98cdccE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -114,19 +114,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hfa5d167701988535E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0a316578559eb371E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17hc18feedbfd2ac264E"
+        "NormalSym": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17h"
       }
     ],
     [
@@ -138,13 +138,13 @@
     [
       29,
       {
-        "NormalSym": "_ZN4core5array8equality103_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$2eq17h1a7481030a69db91E"
+        "NormalSym": "_ZN4core5array8equality103_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$2eq17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -525,7 +525,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h83d84ef21d66e568E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -888,7 +888,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0a316578559eb371E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1069,7 +1069,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h38463d653158c251E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1156,7 +1156,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hf394d43ed8e21e13E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1223,7 +1223,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hedc2c4b05a98cdccE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1382,7 +1382,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hfa5d167701988535E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1421,7 +1421,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h06536692c0aeb15dE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1537,7 +1537,7 @@
           "name": "std::array::equality::<impl std::cmp::PartialEq for [i32; 4]>::eq"
         }
       },
-      "symbol_name": "_ZN4core5array8equality103_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$2eq17h1a7481030a69db91E"
+      "symbol_name": "_ZN4core5array8equality103_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$2eq17h"
     },
     {
       "details": null,
@@ -1633,7 +1633,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h3e77209299d57694E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2207,7 +2207,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN5array4main17h093d1173588c7d34E"
+      "symbol_name": "_ZN5array4main17h"
     },
     {
       "details": null,
@@ -2365,7 +2365,7 @@
           "name": "<i32 as std::array::equality::SpecArrayEq<i32, 4>>::spec_eq"
         }
       },
-      "symbol_name": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17hc18feedbfd2ac264E"
+      "symbol_name": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17h"
     }
   ]
 }

--- a/tests/integration/failing/box.smir.json.expected
+++ b/tests/integration/failing/box.smir.json.expected
@@ -580,25 +580,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h9eaaee507c2d21d0E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h92da431bec4d0519E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h8e7729f80a58ac71E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -610,19 +610,19 @@
     [
       23,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hb15b29e3a14a6765E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hde9006a0949bffcfE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core9panicking14panic_nounwind17hee6445121510e179E"
+        "NormalSym": "_ZN4core9panicking14panic_nounwind17h"
       }
     ],
     [
@@ -634,37 +634,37 @@
     [
       32,
       {
-        "NormalSym": "_ZN4core9panicking9panic_fmt17h8510a50a874ddcc2E"
+        "NormalSym": "_ZN4core9panicking9panic_fmt17h"
       }
     ],
     [
       45,
       {
-        "NormalSym": "_ZN72_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h326b1277d709d8a8E"
+        "NormalSym": "_ZN72_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
       50,
       {
-        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h878684328797f391E"
+        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h"
       }
     ],
     [
       53,
       {
-        "NormalSym": "_ZN5alloc5alloc18handle_alloc_error17h367988acd01d106aE"
+        "NormalSym": "_ZN5alloc5alloc18handle_alloc_error17h"
       }
     ],
     [
       60,
       {
-        "NormalSym": "__rust_alloc"
+        "NormalSym": ""
       }
     ],
     [
       63,
       {
-        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17hd083d5824be049beE"
+        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17h"
       }
     ],
     [
@@ -676,37 +676,37 @@
     [
       66,
       {
-        "NormalSym": "__rust_alloc_zeroed"
+        "NormalSym": "__"
       }
     ],
     [
       67,
       {
-        "NormalSym": "_ZN5alloc5alloc5alloc17h0f1941cd38b492e0E"
+        "NormalSym": "_ZN5alloc5alloc5alloc17h"
       }
     ],
     [
       68,
       {
-        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h577e370d545c7763E"
+        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
       }
     ],
     [
       76,
       {
-        "NormalSym": "_ZN5alloc5alloc15exchange_malloc17h5e6611a095512e8fE"
+        "NormalSym": "_ZN5alloc5alloc15exchange_malloc17h"
       }
     ],
     [
       78,
       {
-        "NormalSym": "__rust_dealloc"
+        "NormalSym": ""
       }
     ],
     [
       79,
       {
-        "NormalSym": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17hb8ea1a8a8ce8e611E"
+        "NormalSym": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17h"
       }
     ],
     [
@@ -718,7 +718,7 @@
     [
       83,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h31446c1bb7428470E"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
       }
     ],
     [
@@ -730,25 +730,25 @@
     [
       87,
       {
-        "NormalSym": "_ZN5alloc5boxed12Box$LT$T$GT$3new17hb7b054b22201ca41E"
+        "NormalSym": "_ZN5alloc5boxed12Box$LT$T$GT$3new17h"
       }
     ],
     [
       88,
       {
-        "NormalSym": "_ZN71_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..cmp..PartialEq$GT$2eq17he8355580e493ee18E"
+        "NormalSym": "_ZN71_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..cmp..PartialEq$GT$2eq17h"
       }
     ],
     [
       89,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
       90,
       {
-        "NormalSym": "_ZN4core3ptr49drop_in_place$LT$alloc..boxed..Box$LT$i32$GT$$GT$17hba8e3b90af82b457E"
+        "NormalSym": "_ZN4core3ptr49drop_in_place$LT$alloc..boxed..Box$LT$i32$GT$$GT$17h"
       }
     ],
     [
@@ -2454,7 +2454,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN3box4main17ha8a3550617341dbeE"
+      "symbol_name": "_ZN3box4main17h"
     },
     {
       "details": null,
@@ -2826,7 +2826,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hfde27f23de2c91dcE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -3189,7 +3189,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hde9006a0949bffcfE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -3370,7 +3370,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h9eaaee507c2d21d0E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -3381,7 +3381,7 @@
           "name": "std::intrinsics::size_of_val::<i32>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics11size_of_val17h7b6b24fed39c5d75E"
+      "symbol_name": "_ZN4core10intrinsics11size_of_val17h"
     },
     {
       "details": null,
@@ -3392,7 +3392,7 @@
           "name": "std::intrinsics::min_align_of_val::<i32>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics16min_align_of_val17h490053aac5bf90ebE"
+      "symbol_name": "_ZN4core10intrinsics16min_align_of_val17h"
     },
     {
       "details": null,
@@ -3572,7 +3572,7 @@
           "name": "std::cmp::impls::<impl std::cmp::PartialEq for i32>::eq"
         }
       },
-      "symbol_name": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17hb8ea1a8a8ce8e611E"
+      "symbol_name": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17h"
     },
     {
       "details": null,
@@ -3659,7 +3659,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hb9952c72c6f60b94E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -3726,7 +3726,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h8e7729f80a58ac71E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -3885,7 +3885,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hb15b29e3a14a6765E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -4993,7 +4993,7 @@
           "name": "std::ptr::read_volatile::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17hd083d5824be049beE"
+      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17h"
     },
     {
       "details": null,
@@ -5252,7 +5252,7 @@
           "name": "std::ptr::drop_in_place::<std::boxed::Box<i32>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr49drop_in_place$LT$alloc..boxed..Box$LT$i32$GT$$GT$17hba8e3b90af82b457E"
+      "symbol_name": "_ZN4core3ptr49drop_in_place$LT$alloc..boxed..Box$LT$i32$GT$$GT$17h"
     },
     {
       "details": null,
@@ -5291,7 +5291,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h7f9f1789552be433E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -5596,7 +5596,7 @@
           "name": "std::ptr::NonNull::<T>::new_unchecked::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h577e370d545c7763E"
+      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
     },
     {
       "details": null,
@@ -5692,7 +5692,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h92da431bec4d0519E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -6536,7 +6536,7 @@
           "name": "alloc::alloc::exchange_malloc"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc15exchange_malloc17h5e6611a095512e8fE"
+      "symbol_name": "_ZN5alloc5alloc15exchange_malloc17h"
     },
     {
       "details": null,
@@ -7490,7 +7490,7 @@
           "name": "std::alloc::alloc"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc5alloc17h0f1941cd38b492e0E"
+      "symbol_name": "_ZN5alloc5alloc5alloc17h"
     },
     {
       "details": null,
@@ -11516,7 +11516,7 @@
           "name": "std::alloc::Global::alloc_impl"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h878684328797f391E"
+      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h"
     },
     {
       "details": null,
@@ -11774,7 +11774,7 @@
           "name": "std::boxed::Box::<i32>::new"
         }
       },
-      "symbol_name": "_ZN5alloc5boxed12Box$LT$T$GT$3new17hb7b054b22201ca41E"
+      "symbol_name": "_ZN5alloc5boxed12Box$LT$T$GT$3new17h"
     },
     {
       "details": null,
@@ -12684,7 +12684,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::deallocate"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h31446c1bb7428470E"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
     },
     {
       "details": null,
@@ -13024,7 +13024,7 @@
           "name": "<std::boxed::Box<i32> as std::cmp::PartialEq>::eq"
         }
       },
-      "symbol_name": "_ZN71_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..cmp..PartialEq$GT$2eq17he8355580e493ee18E"
+      "symbol_name": "_ZN71_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..cmp..PartialEq$GT$2eq17h"
     },
     {
       "details": null,
@@ -14077,7 +14077,7 @@
           "name": "<std::boxed::Box<i32> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN72_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h326b1277d709d8a8E"
+      "symbol_name": "_ZN72_$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     }
   ]
 }

--- a/tests/integration/failing/defined-trait.smir.json.expected
+++ b/tests/integration/failing/defined-trait.smir.json.expected
@@ -1189,25 +1189,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hdaaf8f66ba8b07fbE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17he94a22af18302461E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h451c6b04f22095abE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -1219,19 +1219,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h51bfddf7efe491c8E"
+        "NormalSym": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h3c699aa3dd217762E"
+        "NormalSym": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h"
       }
     ],
     [
       31,
       {
-        "NormalSym": "_ZN4core9panicking14panic_nounwind17hee6445121510e179E"
+        "NormalSym": "_ZN4core9panicking14panic_nounwind17h"
       }
     ],
     [
@@ -1243,37 +1243,37 @@
     [
       33,
       {
-        "NormalSym": "_ZN4core9panicking9panic_fmt17h8510a50a874ddcc2E"
+        "NormalSym": "_ZN4core9panicking9panic_fmt17h"
       }
     ],
     [
       46,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h396ce4bb5a422dd5E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       48,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hbbfbaaa71345ed22E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       51,
       {
-        "NormalSym": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h1a5ac00d73e54207E"
+        "NormalSym": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
       55,
       {
-        "NormalSym": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h1e2744d4a270a4c6E"
+        "NormalSym": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
       61,
       {
-        "NormalSym": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h7a642e4a80f62f08E"
+        "NormalSym": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h"
       }
     ],
     [
@@ -1285,31 +1285,31 @@
     [
       67,
       {
-        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17hd069999b4f72609fE"
+        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17h"
       }
     ],
     [
       69,
       {
-        "NormalSym": "_ZN5alloc7raw_vec12handle_error17h9fbab9c4138a4cf5E"
+        "NormalSym": "_ZN5alloc7raw_vec12handle_error17h"
       }
     ],
     [
       73,
       {
-        "NormalSym": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17ha5b10a238ec55413E"
+        "NormalSym": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17h"
       }
     ],
     [
       78,
       {
-        "NormalSym": "__rust_alloc"
+        "NormalSym": ""
       }
     ],
     [
       79,
       {
-        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17h479600701b538eb1E"
+        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17h"
       }
     ],
     [
@@ -1321,49 +1321,49 @@
     [
       82,
       {
-        "NormalSym": "__rust_alloc_zeroed"
+        "NormalSym": "__"
       }
     ],
     [
       83,
       {
-        "NormalSym": "_ZN5alloc5alloc5alloc17h037977fef949d14aE"
+        "NormalSym": "_ZN5alloc5alloc5alloc17h"
       }
     ],
     [
       84,
       {
-        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h55a6e5449fb88ebeE"
+        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
       }
     ],
     [
       98,
       {
-        "NormalSym": "_ZN4core5alloc6layout6Layout5array5inner17hc1fa8f6ec04d0a03E"
+        "NormalSym": "_ZN4core5alloc6layout6Layout5array5inner17h"
       }
     ],
     [
       99,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17h30a56ef2f8488920E"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17h"
       }
     ],
     [
       100,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17hbc10084ba40edd1aE"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17h"
       }
     ],
     [
       102,
       {
-        "NormalSym": "__rust_dealloc"
+        "NormalSym": ""
       }
     ],
     [
       103,
       {
-        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h387bc55e46abbdf8E"
+        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h"
       }
     ],
     [
@@ -1387,67 +1387,67 @@
     [
       107,
       {
-        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h51fad278440e28deE"
+        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h"
       }
     ],
     [
       108,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17hb55a7883c826734eE"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
       }
     ],
     [
       109,
       {
-        "NormalSym": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h00a00eefcbeb22d7E"
+        "NormalSym": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h"
       }
     ],
     [
       110,
       {
-        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17heed7f68f230f2160E"
+        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
       }
     ],
     [
       116,
       {
-        "NormalSym": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h4c6bc8cbeb8258f7E"
+        "NormalSym": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h"
       }
     ],
     [
       118,
       {
-        "NormalSym": "_ZN67_$LT$defined_trait..Container$u20$as$u20$defined_trait..Summary$GT$9summarise17h1a2582435aa6d75bE"
+        "NormalSym": "_ZN67_$LT$defined_trait..Container$u20$as$u20$defined_trait..Summary$GT$9summarise17h"
       }
     ],
     [
       119,
       {
-        "NormalSym": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17hd089208062269690E"
+        "NormalSym": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h"
       }
     ],
     [
       120,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
       122,
       {
-        "NormalSym": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h850550b9d403c3e1E"
+        "NormalSym": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h"
       }
     ],
     [
       123,
       {
-        "NormalSym": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h62be22db9faf5d6aE"
+        "NormalSym": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h"
       }
     ],
     [
       124,
       {
-        "NormalSym": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h5bb83139422cc7e6E"
+        "NormalSym": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h"
       }
     ],
     [
@@ -2028,7 +2028,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN13defined_trait4main17h45997b5a56c4893fE"
+      "symbol_name": "_ZN13defined_trait4main17h"
     },
     {
       "details": null,
@@ -2400,7 +2400,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h5da45d1d6655e04bE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -2763,7 +2763,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hbbfbaaa71345ed22E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2944,7 +2944,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hdaaf8f66ba8b07fbE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -3296,7 +3296,7 @@
           "name": "<str as std::string::ToString>::to_string"
         }
       },
-      "symbol_name": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h4c6bc8cbeb8258f7E"
+      "symbol_name": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h"
     },
     {
       "details": null,
@@ -3307,7 +3307,7 @@
           "name": "std::intrinsics::size_of_val::<[u8]>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics11size_of_val17hf90fa9d6ad23cd78E"
+      "symbol_name": "_ZN4core10intrinsics11size_of_val17h"
     },
     {
       "details": null,
@@ -5648,7 +5648,7 @@
           "name": "std::intrinsics::copy_nonoverlapping::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17ha5b10a238ec55413E"
+      "symbol_name": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17h"
     },
     {
       "details": null,
@@ -5723,7 +5723,7 @@
           "name": "std::intrinsics::unlikely"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics8unlikely17h1b9c4265ec30503dE"
+      "symbol_name": "_ZN4core10intrinsics8unlikely17h"
     },
     {
       "details": null,
@@ -6159,7 +6159,7 @@
           "name": "core::num::<impl usize>::unchecked_mul::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h7a642e4a80f62f08E"
+      "symbol_name": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h"
     },
     {
       "details": null,
@@ -6246,7 +6246,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h63a9763250dd8e8bE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -6405,7 +6405,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h396ce4bb5a422dd5E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -6472,7 +6472,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h451c6b04f22095abE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -7580,7 +7580,7 @@
           "name": "std::ptr::read_volatile::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17h479600701b538eb1E"
+      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17h"
     },
     {
       "details": null,
@@ -7643,7 +7643,7 @@
           "name": "std::ptr::drop_in_place::<std::string::String>"
         }
       },
-      "symbol_name": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h850550b9d403c3e1E"
+      "symbol_name": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h"
     },
     {
       "details": null,
@@ -7814,7 +7814,7 @@
           "name": "std::ptr::drop_in_place::<std::vec::Vec<u8>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h62be22db9faf5d6aE"
+      "symbol_name": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h"
     },
     {
       "details": null,
@@ -7928,7 +7928,7 @@
           "name": "std::ptr::drop_in_place::<alloc::raw_vec::RawVec<u8>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h5bb83139422cc7e6E"
+      "symbol_name": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h"
     },
     {
       "details": null,
@@ -7967,7 +7967,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17hea919438ab54ed8eE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -8272,7 +8272,7 @@
           "name": "std::ptr::NonNull::<T>::new_unchecked::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h55a6e5449fb88ebeE"
+      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
     },
     {
       "details": null,
@@ -9856,7 +9856,7 @@
           "name": "std::alloc::Layout::array::inner"
         }
       },
-      "symbol_name": "_ZN4core5alloc6layout6Layout5array5inner17hc1fa8f6ec04d0a03E"
+      "symbol_name": "_ZN4core5alloc6layout6Layout5array5inner17h"
     },
     {
       "details": null,
@@ -11503,7 +11503,7 @@
           "name": "std::slice::from_raw_parts::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h00a00eefcbeb22d7E"
+      "symbol_name": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h"
     },
     {
       "details": null,
@@ -12805,7 +12805,7 @@
           "name": "core::ub_checks::is_nonoverlapping::runtime"
         }
       },
-      "symbol_name": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h3c699aa3dd217762E"
+      "symbol_name": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h"
     },
     {
       "details": null,
@@ -14350,7 +14350,7 @@
           "name": "<u8 as std::slice::hack::ConvertVec>::to_vec::<std::alloc::Global>"
         }
       },
-      "symbol_name": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h51bfddf7efe491c8E"
+      "symbol_name": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h"
     },
     {
       "details": null,
@@ -14446,7 +14446,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17he94a22af18302461E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -15400,7 +15400,7 @@
           "name": "std::alloc::alloc"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc5alloc17h037977fef949d14aE"
+      "symbol_name": "_ZN5alloc5alloc5alloc17h"
     },
     {
       "details": null,
@@ -19426,7 +19426,7 @@
           "name": "std::alloc::Global::alloc_impl"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h387bc55e46abbdf8E"
+      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h"
     },
     {
       "details": null,
@@ -20657,7 +20657,7 @@
           "name": "alloc::raw_vec::RawVec::<u8>::current_memory"
         }
       },
-      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h51fad278440e28deE"
+      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h"
     },
     {
       "details": null,
@@ -23329,7 +23329,7 @@
           "name": "alloc::raw_vec::RawVec::<u8>::try_allocate_in"
         }
       },
-      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17hd069999b4f72609fE"
+      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17h"
     },
     {
       "details": null,
@@ -24239,7 +24239,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::deallocate"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17hb55a7883c826734eE"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
     },
     {
       "details": null,
@@ -24377,7 +24377,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::allocate_zeroed"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17h30a56ef2f8488920E"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17h"
     },
     {
       "details": null,
@@ -24515,7 +24515,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::allocate"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17hbc10084ba40edd1aE"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17h"
     },
     {
       "details": null,
@@ -24666,7 +24666,7 @@
           "name": "<Container as Summary>::summarise"
         }
       },
-      "symbol_name": "_ZN67_$LT$defined_trait..Container$u20$as$u20$defined_trait..Summary$GT$9summarise17h1a2582435aa6d75bE"
+      "symbol_name": "_ZN67_$LT$defined_trait..Container$u20$as$u20$defined_trait..Summary$GT$9summarise17h"
     },
     {
       "details": null,
@@ -25201,7 +25201,7 @@
           "name": "<std::vec::Vec<u8> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h1a5ac00d73e54207E"
+      "symbol_name": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     },
     {
       "details": null,
@@ -25888,7 +25888,7 @@
           "name": "<[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal"
         }
       },
-      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17heed7f68f230f2160E"
+      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
     },
     {
       "details": null,
@@ -26316,7 +26316,7 @@
           "name": "<alloc::raw_vec::RawVec<u8> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h1e2744d4a270a4c6E"
+      "symbol_name": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     },
     {
       "details": null,
@@ -27726,7 +27726,7 @@
           "name": "<std::string::String as std::cmp::PartialEq<&str>>::eq"
         }
       },
-      "symbol_name": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17hd089208062269690E"
+      "symbol_name": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h"
     }
   ]
 }

--- a/tests/integration/failing/derive-copy-struct.smir.json.expected
+++ b/tests/integration/failing/derive-copy-struct.smir.json.expected
@@ -55,25 +55,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h16e5330c2a1dc1adE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h8bc2e7fd57893035E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hb7db3fe2604a1199E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -85,43 +85,43 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h849aaec59c3c4beaE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h57bb57d23469420bE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17hc73b0fddf9c6e89dE"
+        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17hd1f3f35f6b6a4554E"
+        "NormalSym": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
       }
     ],
     [
       33,
       {
-        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h4dbf9d27bc3deff5E"
+        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
       }
     ],
     [
       35,
       {
-        "NormalSym": "_ZN18derive_copy_struct20take_first_container17h5e6aa0bbd5320b00E"
+        "NormalSym": "_ZN18derive_copy_struct20take_first_container17h"
       }
     ],
     [
       36,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -350,7 +350,7 @@
           "name": "take_first_container"
         }
       },
-      "symbol_name": "_ZN18derive_copy_struct20take_first_container17h5e6aa0bbd5320b00E"
+      "symbol_name": "_ZN18derive_copy_struct20take_first_container17h"
     },
     {
       "details": null,
@@ -847,7 +847,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN18derive_copy_struct4main17h7f2b938122f7e822E"
+      "symbol_name": "_ZN18derive_copy_struct4main17h"
     },
     {
       "details": null,
@@ -1219,7 +1219,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h10e45513cdd171a5E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1582,7 +1582,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h57bb57d23469420bE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1763,7 +1763,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h16e5330c2a1dc1adE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1850,7 +1850,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h95668bf36d616210E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2009,7 +2009,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h849aaec59c3c4beaE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2076,7 +2076,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hb7db3fe2604a1199E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2115,7 +2115,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17hb8ac2c34a09be70eE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2262,7 +2262,7 @@
           "name": "std::array::<impl std::ops::Index<std::ops::RangeFull> for [Container; 2]>::index"
         }
       },
-      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h4dbf9d27bc3deff5E"
+      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -2378,7 +2378,7 @@
           "name": "core::slice::index::<impl std::ops::Index<std::ops::RangeFull> for [Container]>::index"
         }
       },
-      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17hc73b0fddf9c6e89dE"
+      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -2474,7 +2474,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h8bc2e7fd57893035E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2574,7 +2574,7 @@
           "name": "<std::ops::RangeFull as std::slice::SliceIndex<[Container]>>::index"
         }
       },
-      "symbol_name": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17hd1f3f35f6b6a4554E"
+      "symbol_name": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
     }
   ]
 }

--- a/tests/integration/failing/generic.smir.json.expected
+++ b/tests/integration/failing/generic.smir.json.expected
@@ -109,25 +109,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hea2d76cc64f5da0bE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h3294533c6832f1ebE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h9c63d3cb820058e9E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -139,67 +139,67 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h69bc9c68da00ee1dE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h61748e495429d1d3E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17hf106b89777207b2bE"
+        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h1189d49f8f7ab385E"
+        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
       }
     ],
     [
       32,
       {
-        "NormalSym": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17hc84cc97dcb68f0ccE"
+        "NormalSym": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
       }
     ],
     [
       33,
       {
-        "NormalSym": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17hb38d4c098f158998E"
+        "NormalSym": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
       }
     ],
     [
       38,
       {
-        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17hc486aadb73e3df07E"
+        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
       }
     ],
     [
       40,
       {
-        "NormalSym": "_ZN7generic11index_slice17hb47d8d47e6482c76E"
+        "NormalSym": "_ZN7generic11index_slice17h"
       }
     ],
     [
       41,
       {
-        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17he454f169d3435272E"
+        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
       }
     ],
     [
       42,
       {
-        "NormalSym": "_ZN7generic11index_slice17h40d46dc9ff7722aeE"
+        "NormalSym": "_ZN7generic11index_slice17h"
       }
     ],
     [
       43,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -580,7 +580,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hbb296b96ad86ac07E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -943,7 +943,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h61748e495429d1d3E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1124,7 +1124,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hea2d76cc64f5da0bE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1211,7 +1211,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h2a5244da1ffe2c6aE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1370,7 +1370,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h69bc9c68da00ee1dE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1437,7 +1437,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h9c63d3cb820058e9E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1476,7 +1476,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h8e456511e5036082E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1623,7 +1623,7 @@
           "name": "std::array::<impl std::ops::Index<std::ops::RangeFull> for [i32; 5]>::index"
         }
       },
-      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17hc486aadb73e3df07E"
+      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -1770,7 +1770,7 @@
           "name": "std::array::<impl std::ops::Index<std::ops::RangeFull> for [char; 5]>::index"
         }
       },
-      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17he454f169d3435272E"
+      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -1886,7 +1886,7 @@
           "name": "core::slice::index::<impl std::ops::Index<std::ops::RangeFull> for [char]>::index"
         }
       },
-      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h1189d49f8f7ab385E"
+      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -2002,7 +2002,7 @@
           "name": "core::slice::index::<impl std::ops::Index<std::ops::RangeFull> for [i32]>::index"
         }
       },
-      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17hf106b89777207b2bE"
+      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -2098,7 +2098,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h3294533c6832f1ebE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2295,7 +2295,7 @@
           "name": "index_slice::<char>"
         }
       },
-      "symbol_name": "_ZN7generic11index_slice17h40d46dc9ff7722aeE"
+      "symbol_name": "_ZN7generic11index_slice17h"
     },
     {
       "details": null,
@@ -2492,7 +2492,7 @@
           "name": "index_slice::<i32>"
         }
       },
-      "symbol_name": "_ZN7generic11index_slice17hb47d8d47e6482c76E"
+      "symbol_name": "_ZN7generic11index_slice17h"
     },
     {
       "details": null,
@@ -3441,7 +3441,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN7generic4main17h7a9d065ae1987732E"
+      "symbol_name": "_ZN7generic4main17h"
     },
     {
       "details": null,
@@ -3541,7 +3541,7 @@
           "name": "<std::ops::RangeFull as std::slice::SliceIndex<[i32]>>::index"
         }
       },
-      "symbol_name": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17hb38d4c098f158998E"
+      "symbol_name": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
     },
     {
       "details": null,
@@ -3641,7 +3641,7 @@
           "name": "<std::ops::RangeFull as std::slice::SliceIndex<[char]>>::index"
         }
       },
-      "symbol_name": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17hc84cc97dcb68f0ccE"
+      "symbol_name": "_ZN97_$LT$core..ops..range..RangeFull$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
     }
   ]
 }

--- a/tests/integration/failing/panic_example.smir.json.expected
+++ b/tests/integration/failing/panic_example.smir.json.expected
@@ -497,25 +497,25 @@
     [
       7,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       20,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h163f76a593f9a61dE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       21,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h6e8cf99dfda5fdefE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN3std9panicking11begin_panic28_$u7b$$u7b$closure$u7d$$u7d$17h1ebb1eaab9f30b5aE"
+        "NormalSym": "_ZN3std9panicking11begin_panic28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
@@ -527,7 +527,7 @@
     [
       29,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h11ec6afa27e3d406E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -539,31 +539,31 @@
     [
       31,
       {
-        "NormalSym": "_ZN3std3sys9backtrace26__rust_end_short_backtrace17h4bae7cc86322177bE"
+        "NormalSym": "_ZN3std3sys9backtrace26__rust_end_short_backtrace17h"
       }
     ],
     [
       36,
       {
-        "NormalSym": "_ZN3std9panicking20rust_panic_with_hook17he6fc28793b894d73E"
+        "NormalSym": "_ZN3std9panicking20rust_panic_with_hook17h"
       }
     ],
     [
       42,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h86e2963be1a2fd6aE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       44,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hc407815e8e27866fE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       48,
       {
-        "NormalSym": "_ZN4core9panicking14panic_nounwind17hee6445121510e179E"
+        "NormalSym": "_ZN4core9panicking14panic_nounwind17h"
       }
     ],
     [
@@ -575,31 +575,31 @@
     [
       50,
       {
-        "NormalSym": "_ZN4core9panicking9panic_fmt17h8510a50a874ddcc2E"
+        "NormalSym": "_ZN4core9panicking9panic_fmt17h"
       }
     ],
     [
       63,
       {
-        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17hfeb4b7829cd89493E"
+        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h"
       }
     ],
     [
       66,
       {
-        "NormalSym": "_ZN5alloc5alloc18handle_alloc_error17h367988acd01d106aE"
+        "NormalSym": "_ZN5alloc5alloc18handle_alloc_error17h"
       }
     ],
     [
       73,
       {
-        "NormalSym": "__rust_alloc"
+        "NormalSym": ""
       }
     ],
     [
       75,
       {
-        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17hc773488a477a662fE"
+        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17h"
       }
     ],
     [
@@ -611,55 +611,55 @@
     [
       78,
       {
-        "NormalSym": "__rust_alloc_zeroed"
+        "NormalSym": "__"
       }
     ],
     [
       79,
       {
-        "NormalSym": "_ZN5alloc5alloc5alloc17h214157fcd92df279E"
+        "NormalSym": "_ZN5alloc5alloc5alloc17h"
       }
     ],
     [
       80,
       {
-        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h180abd43edd08785E"
+        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
       }
     ],
     [
       88,
       {
-        "NormalSym": "_ZN5alloc5alloc15exchange_malloc17h5443007c4b77064aE"
+        "NormalSym": "_ZN5alloc5alloc15exchange_malloc17h"
       }
     ],
     [
       93,
       {
-        "NormalSym": "_ZN3std7process5abort17h4d7b628a2864edb7E"
+        "NormalSym": "_ZN3std7process5abort17h"
       }
     ],
     [
       94,
       {
-        "NormalSym": "_ZN3std9panicking14payload_as_str17h5ede2995a2a0c693E"
+        "NormalSym": "_ZN3std9panicking14payload_as_str17h"
       }
     ],
     [
       96,
       {
-        "NormalSym": "_ZN4core3fmt9Formatter9write_str17hd334b351ded225feE"
+        "NormalSym": "_ZN4core3fmt9Formatter9write_str17h"
       }
     ],
     [
       101,
       {
-        "NormalSym": "_ZN5alloc5boxed12Box$LT$T$GT$3new17hfb7bad2afdef8431E"
+        "NormalSym": "_ZN5alloc5boxed12Box$LT$T$GT$3new17h"
       }
     ],
     [
       112,
       {
-        "NormalSym": "_ZN3std9panicking11begin_panic17h046658c3c0b9185bE"
+        "NormalSym": "_ZN3std9panicking11begin_panic17h"
       }
     ],
     [
@@ -783,7 +783,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN13panic_example4main17h1a3a8ec0839c9696E"
+      "symbol_name": "_ZN13panic_example4main17h"
     },
     {
       "details": null,
@@ -1153,7 +1153,7 @@
           "name": "<&str as std::any::Any>::type_id"
         }
       },
-      "symbol_name": "_ZN36_$LT$T$u20$as$u20$core..any..Any$GT$7type_id17h5fbaa8559e09a241E"
+      "symbol_name": "_ZN36_$LT$T$u20$as$u20$core..any..Any$GT$7type_id17h"
     },
     {
       "details": null,
@@ -1525,7 +1525,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hd4017724170dc624E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1888,7 +1888,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hc407815e8e27866fE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2069,7 +2069,7 @@
           "name": "std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::rt::begin_panic<&str>::{closure#0}}, !>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace26__rust_end_short_backtrace17h4bae7cc86322177bE"
+      "symbol_name": "_ZN3std3sys9backtrace26__rust_end_short_backtrace17h"
     },
     {
       "details": null,
@@ -2250,7 +2250,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h163f76a593f9a61dE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -2448,7 +2448,7 @@
           "name": "std::rt::begin_panic::<&str>"
         }
       },
-      "symbol_name": "_ZN3std9panicking11begin_panic17h046658c3c0b9185bE"
+      "symbol_name": "_ZN3std9panicking11begin_panic17h"
     },
     {
       "details": null,
@@ -2890,7 +2890,7 @@
           "name": "std::rt::begin_panic::<&str>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std9panicking11begin_panic28_$u7b$$u7b$closure$u7d$$u7d$17h1ebb1eaab9f30b5aE"
+      "symbol_name": "_ZN3std9panicking11begin_panic28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2901,7 +2901,7 @@
           "name": "std::intrinsics::type_id::<&str>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics7type_id17h948ad9d7a3771dcdE"
+      "symbol_name": "_ZN4core10intrinsics7type_id17h"
     },
     {
       "details": null,
@@ -2988,7 +2988,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h0b6b3134fd4818cdE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -3055,7 +3055,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h11ec6afa27e3d406E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -3214,7 +3214,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h86e2963be1a2fd6aE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -4322,7 +4322,7 @@
           "name": "std::ptr::read_volatile::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17hc773488a477a662fE"
+      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17h"
     },
     {
       "details": null,
@@ -4361,7 +4361,7 @@
           "name": "std::ptr::drop_in_place::<&str>"
         }
       },
-      "symbol_name": "_ZN4core3ptr28drop_in_place$LT$$RF$str$GT$17h77c483de56b3845cE"
+      "symbol_name": "_ZN4core3ptr28drop_in_place$LT$$RF$str$GT$17h"
     },
     {
       "details": null,
@@ -4400,7 +4400,7 @@
           "name": "std::ptr::drop_in_place::<std::rt::begin_panic::Payload<&str>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr72drop_in_place$LT$std..panicking..begin_panic..Payload$LT$$RF$str$GT$$GT$17h1b47a62f19fbd5f1E"
+      "symbol_name": "_ZN4core3ptr72drop_in_place$LT$std..panicking..begin_panic..Payload$LT$$RF$str$GT$$GT$17h"
     },
     {
       "details": null,
@@ -4439,7 +4439,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h21a5cf619fdd0e23E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -4744,7 +4744,7 @@
           "name": "std::ptr::NonNull::<T>::new_unchecked::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h180abd43edd08785E"
+      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
     },
     {
       "details": null,
@@ -4850,7 +4850,7 @@
           "name": "<std::rt::begin_panic::Payload<&str> as core::panic::PanicPayload>::as_str"
         }
       },
-      "symbol_name": "_ZN4core5panic12PanicPayload6as_str17h34f70170a81b2c4bE"
+      "symbol_name": "_ZN4core5panic12PanicPayload6as_str17h"
     },
     {
       "details": null,
@@ -4946,7 +4946,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h6e8cf99dfda5fdefE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -5790,7 +5790,7 @@
           "name": "alloc::alloc::exchange_malloc"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc15exchange_malloc17h5443007c4b77064aE"
+      "symbol_name": "_ZN5alloc5alloc15exchange_malloc17h"
     },
     {
       "details": null,
@@ -6744,7 +6744,7 @@
           "name": "std::alloc::alloc"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc5alloc17h214157fcd92df279E"
+      "symbol_name": "_ZN5alloc5alloc5alloc17h"
     },
     {
       "details": null,
@@ -10770,7 +10770,7 @@
           "name": "std::alloc::Global::alloc_impl"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17hfeb4b7829cd89493E"
+      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h"
     },
     {
       "details": null,
@@ -11028,7 +11028,7 @@
           "name": "std::boxed::Box::<&str>::new"
         }
       },
-      "symbol_name": "_ZN5alloc5boxed12Box$LT$T$GT$3new17hfb7bad2afdef8431E"
+      "symbol_name": "_ZN5alloc5boxed12Box$LT$T$GT$3new17h"
     },
     {
       "details": null,
@@ -11458,7 +11458,7 @@
           "name": "<std::rt::begin_panic::Payload<&str> as std::fmt::Display>::fmt"
         }
       },
-      "symbol_name": "_ZN84_$LT$std..panicking..begin_panic..Payload$LT$A$GT$$u20$as$u20$core..fmt..Display$GT$3fmt17h2995801f2bca7f36E"
+      "symbol_name": "_ZN84_$LT$std..panicking..begin_panic..Payload$LT$A$GT$$u20$as$u20$core..fmt..Display$GT$3fmt17h"
     },
     {
       "details": null,
@@ -11768,7 +11768,7 @@
           "name": "<std::rt::begin_panic::Payload<&str> as core::panic::PanicPayload>::get"
         }
       },
-      "symbol_name": "_ZN91_$LT$std..panicking..begin_panic..Payload$LT$A$GT$$u20$as$u20$core..panic..PanicPayload$GT$3get17h7e5b46332dff10e9E"
+      "symbol_name": "_ZN91_$LT$std..panicking..begin_panic..Payload$LT$A$GT$$u20$as$u20$core..panic..PanicPayload$GT$3get17h"
     },
     {
       "details": null,
@@ -12772,7 +12772,7 @@
           "name": "<std::rt::begin_panic::Payload<&str> as core::panic::PanicPayload>::take_box"
         }
       },
-      "symbol_name": "_ZN91_$LT$std..panicking..begin_panic..Payload$LT$A$GT$$u20$as$u20$core..panic..PanicPayload$GT$8take_box17h38a7afb365d90d28E"
+      "symbol_name": "_ZN91_$LT$std..panicking..begin_panic..Payload$LT$A$GT$$u20$as$u20$core..panic..PanicPayload$GT$8take_box17h"
     }
   ]
 }

--- a/tests/integration/failing/std-string-empty.smir.json.expected
+++ b/tests/integration/failing/std-string-empty.smir.json.expected
@@ -559,25 +559,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h8a4d857081dbfaf6E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hbf94cbfcda9701e6E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17heba02fa12c9fe2d9E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -589,31 +589,31 @@
     [
       23,
       {
-        "NormalSym": "_ZN4core9panicking14panic_nounwind17hee6445121510e179E"
+        "NormalSym": "_ZN4core9panicking14panic_nounwind17h"
       }
     ],
     [
       28,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17he70aeb4246727f24E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h1929e2e8e9434881E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       34,
       {
-        "NormalSym": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17ha7e6a1ccddf30af0E"
+        "NormalSym": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
       38,
       {
-        "NormalSym": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17hdec771535c18b312E"
+        "NormalSym": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
@@ -625,19 +625,19 @@
     [
       44,
       {
-        "NormalSym": "_ZN4core9panicking9panic_fmt17h8510a50a874ddcc2E"
+        "NormalSym": "_ZN4core9panicking9panic_fmt17h"
       }
     ],
     [
       57,
       {
-        "NormalSym": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17hbe9fc50f0b01d61dE"
+        "NormalSym": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h"
       }
     ],
     [
       65,
       {
-        "NormalSym": "__rust_dealloc"
+        "NormalSym": ""
       }
     ],
     [
@@ -661,55 +661,55 @@
     [
       77,
       {
-        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h36f247bc9566572eE"
+        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h"
       }
     ],
     [
       78,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h04db9e7ed4d0984aE"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
       }
     ],
     [
       79,
       {
-        "NormalSym": "_ZN4core5slice3raw14from_raw_parts18precondition_check17hd731fe266d532e13E"
+        "NormalSym": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h"
       }
     ],
     [
       80,
       {
-        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h48a560245506d1e3E"
+        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
       }
     ],
     [
       86,
       {
-        "NormalSym": "_ZN5alloc6string6String3new17h10f73349ad3baa53E"
+        "NormalSym": "_ZN5alloc6string6String3new17h"
       }
     ],
     [
       87,
       {
-        "NormalSym": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h563fb1f7b684b2a7E"
+        "NormalSym": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h"
       }
     ],
     [
       88,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
       89,
       {
-        "NormalSym": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17ha4e7fc423a077132E"
+        "NormalSym": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h"
       }
     ],
     [
       90,
       {
-        "NormalSym": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h63cbb232c447c463E"
+        "NormalSym": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h"
       }
     ],
     [
@@ -721,7 +721,7 @@
     [
       92,
       {
-        "NormalSym": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h0beb4ebee2e07298E"
+        "NormalSym": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h"
       }
     ]
   ],
@@ -1184,7 +1184,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN16std_string_empty4main17hd07ef96c1ecf9236E"
+      "symbol_name": "_ZN16std_string_empty4main17h"
     },
     {
       "details": null,
@@ -1556,7 +1556,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h9123a60f5321d3daE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1919,7 +1919,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h1929e2e8e9434881E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2100,7 +2100,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h8a4d857081dbfaf6E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -2111,7 +2111,7 @@
           "name": "std::intrinsics::size_of_val::<[u8]>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics11size_of_val17hb66943408c33bf76E"
+      "symbol_name": "_ZN4core10intrinsics11size_of_val17h"
     },
     {
       "details": null,
@@ -2547,7 +2547,7 @@
           "name": "core::num::<impl usize>::unchecked_mul::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17hbe9fc50f0b01d61dE"
+      "symbol_name": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h"
     },
     {
       "details": null,
@@ -2634,7 +2634,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17ha8ba36b85ae7fbb9E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2793,7 +2793,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17he70aeb4246727f24E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2860,7 +2860,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17heba02fa12c9fe2d9E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2923,7 +2923,7 @@
           "name": "std::ptr::drop_in_place::<std::string::String>"
         }
       },
-      "symbol_name": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17ha4e7fc423a077132E"
+      "symbol_name": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h"
     },
     {
       "details": null,
@@ -3094,7 +3094,7 @@
           "name": "std::ptr::drop_in_place::<std::vec::Vec<u8>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h63cbb232c447c463E"
+      "symbol_name": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h"
     },
     {
       "details": null,
@@ -3208,7 +3208,7 @@
           "name": "std::ptr::drop_in_place::<alloc::raw_vec::RawVec<u8>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h0beb4ebee2e07298E"
+      "symbol_name": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h"
     },
     {
       "details": null,
@@ -3247,7 +3247,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17hd3783a560cffe87eE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -4894,7 +4894,7 @@
           "name": "std::slice::from_raw_parts::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core5slice3raw14from_raw_parts18precondition_check17hd731fe266d532e13E"
+      "symbol_name": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h"
     },
     {
       "details": null,
@@ -4990,7 +4990,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hbf94cbfcda9701e6E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -5173,7 +5173,7 @@
           "name": "std::string::String::new"
         }
       },
-      "symbol_name": "_ZN5alloc6string6String3new17h10f73349ad3baa53E"
+      "symbol_name": "_ZN5alloc6string6String3new17h"
     },
     {
       "details": null,
@@ -6404,7 +6404,7 @@
           "name": "alloc::raw_vec::RawVec::<u8>::current_memory"
         }
       },
-      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h36f247bc9566572eE"
+      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h"
     },
     {
       "details": null,
@@ -7314,7 +7314,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::deallocate"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h04db9e7ed4d0984aE"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
     },
     {
       "details": null,
@@ -7849,7 +7849,7 @@
           "name": "<std::vec::Vec<u8> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17ha7e6a1ccddf30af0E"
+      "symbol_name": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     },
     {
       "details": null,
@@ -8536,7 +8536,7 @@
           "name": "<[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal"
         }
       },
-      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h48a560245506d1e3E"
+      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
     },
     {
       "details": null,
@@ -8964,7 +8964,7 @@
           "name": "<alloc::raw_vec::RawVec<u8> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17hdec771535c18b312E"
+      "symbol_name": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     },
     {
       "details": null,
@@ -10374,7 +10374,7 @@
           "name": "<std::string::String as std::cmp::PartialEq<&str>>::eq"
         }
       },
-      "symbol_name": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h563fb1f7b684b2a7E"
+      "symbol_name": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h"
     }
   ]
 }

--- a/tests/integration/failing/std-to-string.smir.json.expected
+++ b/tests/integration/failing/std-to-string.smir.json.expected
@@ -1083,25 +1083,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h90dbb03933786387E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h02d1417dff5cd826E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h5b4cd0dacfd81eb4E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -1113,19 +1113,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h33b8a6e5a0a7dfc4E"
+        "NormalSym": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h6c25e126a2602078E"
+        "NormalSym": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h"
       }
     ],
     [
       31,
       {
-        "NormalSym": "_ZN4core9panicking14panic_nounwind17hee6445121510e179E"
+        "NormalSym": "_ZN4core9panicking14panic_nounwind17h"
       }
     ],
     [
@@ -1137,37 +1137,37 @@
     [
       33,
       {
-        "NormalSym": "_ZN4core9panicking9panic_fmt17h8510a50a874ddcc2E"
+        "NormalSym": "_ZN4core9panicking9panic_fmt17h"
       }
     ],
     [
       46,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17ha82058174da31196E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       48,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h16fd98eaacdce366E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       51,
       {
-        "NormalSym": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17ha2b06c17550c4594E"
+        "NormalSym": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
       55,
       {
-        "NormalSym": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h9f21d22221a217aaE"
+        "NormalSym": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
       }
     ],
     [
       61,
       {
-        "NormalSym": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h147a48bdfc9cebaeE"
+        "NormalSym": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h"
       }
     ],
     [
@@ -1179,31 +1179,31 @@
     [
       67,
       {
-        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17hde8132f4f12532dbE"
+        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17h"
       }
     ],
     [
       69,
       {
-        "NormalSym": "_ZN5alloc7raw_vec12handle_error17h9fbab9c4138a4cf5E"
+        "NormalSym": "_ZN5alloc7raw_vec12handle_error17h"
       }
     ],
     [
       73,
       {
-        "NormalSym": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17h9f024a4c9fa2be1dE"
+        "NormalSym": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17h"
       }
     ],
     [
       78,
       {
-        "NormalSym": "__rust_alloc"
+        "NormalSym": ""
       }
     ],
     [
       79,
       {
-        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17h728cba60bee17784E"
+        "NormalSym": "_ZN4core3ptr13read_volatile18precondition_check17h"
       }
     ],
     [
@@ -1215,49 +1215,49 @@
     [
       82,
       {
-        "NormalSym": "__rust_alloc_zeroed"
+        "NormalSym": "__"
       }
     ],
     [
       83,
       {
-        "NormalSym": "_ZN5alloc5alloc5alloc17h0dca39f7982a9f7aE"
+        "NormalSym": "_ZN5alloc5alloc5alloc17h"
       }
     ],
     [
       84,
       {
-        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17hee0e8c7ad69a05ffE"
+        "NormalSym": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
       }
     ],
     [
       98,
       {
-        "NormalSym": "_ZN4core5alloc6layout6Layout5array5inner17h94147f78f9e43dd8E"
+        "NormalSym": "_ZN4core5alloc6layout6Layout5array5inner17h"
       }
     ],
     [
       99,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17hd1378b6fec98ecddE"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17h"
       }
     ],
     [
       100,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17hc5b4e4962fb0f40dE"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17h"
       }
     ],
     [
       102,
       {
-        "NormalSym": "__rust_dealloc"
+        "NormalSym": ""
       }
     ],
     [
       103,
       {
-        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h3e8e7b3e0f598119E"
+        "NormalSym": "_ZN5alloc5alloc6Global10alloc_impl17h"
       }
     ],
     [
@@ -1281,49 +1281,49 @@
     [
       107,
       {
-        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17hba8a41dea17e13ccE"
+        "NormalSym": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h"
       }
     ],
     [
       108,
       {
-        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h92716973ef61186eE"
+        "NormalSym": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
       }
     ],
     [
       109,
       {
-        "NormalSym": "_ZN4core5slice3raw14from_raw_parts18precondition_check17hf3a78f9699bce1d6E"
+        "NormalSym": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h"
       }
     ],
     [
       110,
       {
-        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h812ed04340e8bc65E"
+        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
       }
     ],
     [
       116,
       {
-        "NormalSym": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h34ab2d3d44afb0cfE"
+        "NormalSym": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h"
       }
     ],
     [
       117,
       {
-        "NormalSym": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h9c119bf760646bc2E"
+        "NormalSym": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h"
       }
     ],
     [
       118,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
       119,
       {
-        "NormalSym": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h471900168bc51ec1E"
+        "NormalSym": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h"
       }
     ],
     [
@@ -1335,13 +1335,13 @@
     [
       121,
       {
-        "NormalSym": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h9c3d7457c17d0509E"
+        "NormalSym": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h"
       }
     ],
     [
       123,
       {
-        "NormalSym": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h5579b46778b517b5E"
+        "NormalSym": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h"
       }
     ],
     [
@@ -1878,7 +1878,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN13std_to_string4main17hbc4dd8701049b509E"
+      "symbol_name": "_ZN13std_to_string4main17h"
     },
     {
       "details": null,
@@ -2250,7 +2250,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h5ce59742aa8ff7b2E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -2613,7 +2613,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h16fd98eaacdce366E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2794,7 +2794,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h90dbb03933786387E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -3146,7 +3146,7 @@
           "name": "<str as std::string::ToString>::to_string"
         }
       },
-      "symbol_name": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h34ab2d3d44afb0cfE"
+      "symbol_name": "_ZN47_$LT$str$u20$as$u20$alloc..string..ToString$GT$9to_string17h"
     },
     {
       "details": null,
@@ -3157,7 +3157,7 @@
           "name": "std::intrinsics::size_of_val::<[u8]>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics11size_of_val17hfbc7cf1f1af1c1e6E"
+      "symbol_name": "_ZN4core10intrinsics11size_of_val17h"
     },
     {
       "details": null,
@@ -5498,7 +5498,7 @@
           "name": "std::intrinsics::copy_nonoverlapping::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17h9f024a4c9fa2be1dE"
+      "symbol_name": "_ZN4core10intrinsics19copy_nonoverlapping18precondition_check17h"
     },
     {
       "details": null,
@@ -5573,7 +5573,7 @@
           "name": "std::intrinsics::unlikely"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics8unlikely17h1ce0cbb60d79001aE"
+      "symbol_name": "_ZN4core10intrinsics8unlikely17h"
     },
     {
       "details": null,
@@ -6009,7 +6009,7 @@
           "name": "core::num::<impl usize>::unchecked_mul::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h147a48bdfc9cebaeE"
+      "symbol_name": "_ZN4core3num23_$LT$impl$u20$usize$GT$13unchecked_mul18precondition_check17h"
     },
     {
       "details": null,
@@ -6096,7 +6096,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h2bff7de0843201b5E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -6163,7 +6163,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h5b4cd0dacfd81eb4E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -6322,7 +6322,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17ha82058174da31196E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -7430,7 +7430,7 @@
           "name": "std::ptr::read_volatile::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17h728cba60bee17784E"
+      "symbol_name": "_ZN4core3ptr13read_volatile18precondition_check17h"
     },
     {
       "details": null,
@@ -7493,7 +7493,7 @@
           "name": "std::ptr::drop_in_place::<std::string::String>"
         }
       },
-      "symbol_name": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h5579b46778b517b5E"
+      "symbol_name": "_ZN4core3ptr42drop_in_place$LT$alloc..string..String$GT$17h"
     },
     {
       "details": null,
@@ -7664,7 +7664,7 @@
           "name": "std::ptr::drop_in_place::<std::vec::Vec<u8>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h9c3d7457c17d0509E"
+      "symbol_name": "_ZN4core3ptr46drop_in_place$LT$alloc..vec..Vec$LT$u8$GT$$GT$17h"
     },
     {
       "details": null,
@@ -7778,7 +7778,7 @@
           "name": "std::ptr::drop_in_place::<alloc::raw_vec::RawVec<u8>>"
         }
       },
-      "symbol_name": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h471900168bc51ec1E"
+      "symbol_name": "_ZN4core3ptr53drop_in_place$LT$alloc..raw_vec..RawVec$LT$u8$GT$$GT$17h"
     },
     {
       "details": null,
@@ -7817,7 +7817,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17hd383971480c11f2aE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -8122,7 +8122,7 @@
           "name": "std::ptr::NonNull::<T>::new_unchecked::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17hee0e8c7ad69a05ffE"
+      "symbol_name": "_ZN4core3ptr8non_null16NonNull$LT$T$GT$13new_unchecked18precondition_check17h"
     },
     {
       "details": null,
@@ -9706,7 +9706,7 @@
           "name": "std::alloc::Layout::array::inner"
         }
       },
-      "symbol_name": "_ZN4core5alloc6layout6Layout5array5inner17h94147f78f9e43dd8E"
+      "symbol_name": "_ZN4core5alloc6layout6Layout5array5inner17h"
     },
     {
       "details": null,
@@ -11353,7 +11353,7 @@
           "name": "std::slice::from_raw_parts::precondition_check"
         }
       },
-      "symbol_name": "_ZN4core5slice3raw14from_raw_parts18precondition_check17hf3a78f9699bce1d6E"
+      "symbol_name": "_ZN4core5slice3raw14from_raw_parts18precondition_check17h"
     },
     {
       "details": null,
@@ -12655,7 +12655,7 @@
           "name": "core::ub_checks::is_nonoverlapping::runtime"
         }
       },
-      "symbol_name": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h6c25e126a2602078E"
+      "symbol_name": "_ZN4core9ub_checks17is_nonoverlapping7runtime17h"
     },
     {
       "details": null,
@@ -14200,7 +14200,7 @@
           "name": "<u8 as std::slice::hack::ConvertVec>::to_vec::<std::alloc::Global>"
         }
       },
-      "symbol_name": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h33b8a6e5a0a7dfc4E"
+      "symbol_name": "_ZN52_$LT$T$u20$as$u20$alloc..slice..hack..ConvertVec$GT$6to_vec17h"
     },
     {
       "details": null,
@@ -14296,7 +14296,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h02d1417dff5cd826E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -15250,7 +15250,7 @@
           "name": "std::alloc::alloc"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc5alloc17h0dca39f7982a9f7aE"
+      "symbol_name": "_ZN5alloc5alloc5alloc17h"
     },
     {
       "details": null,
@@ -19276,7 +19276,7 @@
           "name": "std::alloc::Global::alloc_impl"
         }
       },
-      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h3e8e7b3e0f598119E"
+      "symbol_name": "_ZN5alloc5alloc6Global10alloc_impl17h"
     },
     {
       "details": null,
@@ -20507,7 +20507,7 @@
           "name": "alloc::raw_vec::RawVec::<u8>::current_memory"
         }
       },
-      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17hba8a41dea17e13ccE"
+      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$14current_memory17h"
     },
     {
       "details": null,
@@ -23179,7 +23179,7 @@
           "name": "alloc::raw_vec::RawVec::<u8>::try_allocate_in"
         }
       },
-      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17hde8132f4f12532dbE"
+      "symbol_name": "_ZN5alloc7raw_vec19RawVec$LT$T$C$A$GT$15try_allocate_in17h"
     },
     {
       "details": null,
@@ -24089,7 +24089,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::deallocate"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h92716973ef61186eE"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$10deallocate17h"
     },
     {
       "details": null,
@@ -24227,7 +24227,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::allocate_zeroed"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17hd1378b6fec98ecddE"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$15allocate_zeroed17h"
     },
     {
       "details": null,
@@ -24365,7 +24365,7 @@
           "name": "<std::alloc::Global as std::alloc::Allocator>::allocate"
         }
       },
-      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17hc5b4e4962fb0f40dE"
+      "symbol_name": "_ZN63_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$8allocate17h"
     },
     {
       "details": null,
@@ -24900,7 +24900,7 @@
           "name": "<std::vec::Vec<u8> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17ha2b06c17550c4594E"
+      "symbol_name": "_ZN70_$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     },
     {
       "details": null,
@@ -25587,7 +25587,7 @@
           "name": "<[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal"
         }
       },
-      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h812ed04340e8bc65E"
+      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
     },
     {
       "details": null,
@@ -26015,7 +26015,7 @@
           "name": "<alloc::raw_vec::RawVec<u8> as std::ops::Drop>::drop"
         }
       },
-      "symbol_name": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h9f21d22221a217aaE"
+      "symbol_name": "_ZN77_$LT$alloc..raw_vec..RawVec$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$4drop17h"
     },
     {
       "details": null,
@@ -27425,7 +27425,7 @@
           "name": "<std::string::String as std::cmp::PartialEq<&str>>::eq"
         }
       },
-      "symbol_name": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h9c119bf760646bc2E"
+      "symbol_name": "_ZN77_$LT$alloc..string..String$u20$as$u20$core..cmp..PartialEq$LT$$RF$str$GT$$GT$2eq17h"
     }
   ]
 }

--- a/tests/integration/failing/str-empty.smir.json.expected
+++ b/tests/integration/failing/str-empty.smir.json.expected
@@ -118,25 +118,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h544ca298fd981893E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h4e60a16e561622f8E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h2df40009830159bbE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -148,25 +148,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17h7ebea87933a96534E"
+        "NormalSym": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h69cf50aaff9f5c63E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8a7a569958061d49E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h29105622a154f963E"
+        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
       }
     ],
     [
@@ -184,13 +184,13 @@
     [
       37,
       {
-        "NormalSym": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17he0d203be58d060afE"
+        "NormalSym": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17h"
       }
     ],
     [
       38,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -571,7 +571,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h5d645f8826581ab5E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -934,7 +934,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8a7a569958061d49E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1115,7 +1115,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h544ca298fd981893E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1126,7 +1126,7 @@
           "name": "std::intrinsics::size_of_val::<[u8]>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics11size_of_val17h0266a439570c5ebeE"
+      "symbol_name": "_ZN4core10intrinsics11size_of_val17h"
     },
     {
       "details": null,
@@ -1295,7 +1295,7 @@
           "name": "std::cmp::impls::<impl std::cmp::PartialEq for &str>::eq"
         }
       },
-      "symbol_name": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17he0d203be58d060afE"
+      "symbol_name": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17h"
     },
     {
       "details": null,
@@ -1382,7 +1382,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h182d0d446cc06b0eE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1449,7 +1449,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h2df40009830159bbE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1608,7 +1608,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h69cf50aaff9f5c63E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1647,7 +1647,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h8b98d3f8513266f6E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1991,7 +1991,7 @@
           "name": "core::str::traits::<impl std::cmp::PartialEq for str>::eq"
         }
       },
-      "symbol_name": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17h7ebea87933a96534E"
+      "symbol_name": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17h"
     },
     {
       "details": null,
@@ -2087,7 +2087,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h4e60a16e561622f8E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2774,7 +2774,7 @@
           "name": "<[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal"
         }
       },
-      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h29105622a154f963E"
+      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
     },
     {
       "details": null,
@@ -3218,7 +3218,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN9str_empty4main17hf8e3421947f62c31E"
+      "symbol_name": "_ZN9str_empty4main17h"
     }
   ]
 }

--- a/tests/integration/failing/str-trivial.smir.json.expected
+++ b/tests/integration/failing/str-trivial.smir.json.expected
@@ -125,25 +125,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17heb0630f5a0cd5086E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h2d18d5a9e8fb95abE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hca1f8df10907907fE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -155,25 +155,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17hc7a6bff4c06f14a6E"
+        "NormalSym": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h17ebc11c61414b3aE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8cce9b152dc9cb99E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h5e8e428385f25c8bE"
+        "NormalSym": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
       }
     ],
     [
@@ -191,13 +191,13 @@
     [
       37,
       {
-        "NormalSym": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17h6c4717c569400301E"
+        "NormalSym": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17h"
       }
     ],
     [
       38,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -650,7 +650,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN11str_trivial4main17hd1f2bc6fabc04c2dE"
+      "symbol_name": "_ZN11str_trivial4main17h"
     },
     {
       "details": null,
@@ -1022,7 +1022,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h28916d16c5f1dccaE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1385,7 +1385,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8cce9b152dc9cb99E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1566,7 +1566,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17heb0630f5a0cd5086E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1577,7 +1577,7 @@
           "name": "std::intrinsics::size_of_val::<[u8]>"
         }
       },
-      "symbol_name": "_ZN4core10intrinsics11size_of_val17hcf585b6f6289e086E"
+      "symbol_name": "_ZN4core10intrinsics11size_of_val17h"
     },
     {
       "details": null,
@@ -1746,7 +1746,7 @@
           "name": "std::cmp::impls::<impl std::cmp::PartialEq for &str>::eq"
         }
       },
-      "symbol_name": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17h6c4717c569400301E"
+      "symbol_name": "_ZN4core3cmp5impls69_$LT$impl$u20$core..cmp..PartialEq$LT$$RF$B$GT$$u20$for$u20$$RF$A$GT$2eq17h"
     },
     {
       "details": null,
@@ -1833,7 +1833,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h21fff4c9e2eedc00E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1992,7 +1992,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h17ebc11c61414b3aE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2059,7 +2059,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hca1f8df10907907fE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2098,7 +2098,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h9a2a29885f89000bE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2442,7 +2442,7 @@
           "name": "core::str::traits::<impl std::cmp::PartialEq for str>::eq"
         }
       },
-      "symbol_name": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17hc7a6bff4c06f14a6E"
+      "symbol_name": "_ZN4core3str6traits54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$str$GT$2eq17h"
     },
     {
       "details": null,
@@ -2538,7 +2538,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h2d18d5a9e8fb95abE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -3225,7 +3225,7 @@
           "name": "<[u8] as core::slice::cmp::SlicePartialEq<u8>>::equal"
         }
       },
-      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h5e8e428385f25c8bE"
+      "symbol_name": "_ZN73_$LT$$u5b$A$u5d$$u20$as$u20$core..slice..cmp..SlicePartialEq$LT$B$GT$$GT$5equal17h"
     }
   ]
 }

--- a/tests/integration/normalise-filter.jq
+++ b/tests/integration/normalise-filter.jq
@@ -1,3 +1,8 @@
+# Remove the hashes at the end of mangled names
+.functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = .[1].NormalSym[:-17] else .  end ] )
+    | .items = ( [ .items[] | if .symbol_name then .symbol_name = .symbol_name[:-17] else .  end ] )
+    |
+# Apply the normalisation filter
 { allocs:
     ( [ .allocs[] ]
 # sort allocs by their ID

--- a/tests/integration/pre-filter.jq
+++ b/tests/integration/pre-filter.jq
@@ -1,2 +1,0 @@
-.functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = .[1].NormalSym[:-17] else .  end ] )
-    | .items = ( [ .items[] | if .symbol_name then .symbol_name = .symbol_name[:-17] else .  end ] )

--- a/tests/integration/pre-filter.jq
+++ b/tests/integration/pre-filter.jq
@@ -1,2 +1,2 @@
-.functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = (.[1].NormalSym | sub("17h.*$"; "HASH")) else .  end ] )
-    | .items = ( [ .items[] | if .symbol_name then .symbol_name = ( .symbol_name | sub("17h.*$"; "HASH")) else .  end ] )
+.functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = .[1].NormalSym[:-17] else .  end ] )
+    | .items = ( [ .items[] | if .symbol_name then .symbol_name = .symbol_name[:-17] else .  end ] )

--- a/tests/integration/pre-filter.jq
+++ b/tests/integration/pre-filter.jq
@@ -1,1 +1,2 @@
 .functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = (.[1].NormalSym | sub("17h.*$"; "HASH")) else .  end ] )
+    | .items = ( [ .items[] | if .symbol_name then .symbol_name = ( .symbol_name | sub("17h.*$"; "HASH")) else .  end ] )

--- a/tests/integration/pre-filter.jq
+++ b/tests/integration/pre-filter.jq
@@ -1,0 +1,1 @@
+.functions = ( [ .functions[] | if .[1].NormalSym then .[1].NormalSym = (.[1].NormalSym | sub("17h.*$"; "HASH")) else .  end ] )

--- a/tests/integration/programs/assert_eq.smir.json.expected
+++ b/tests/integration/programs/assert_eq.smir.json.expected
@@ -4,25 +4,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he770fc9c7f092400E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hb06ebd36cf1fd65bE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h50b93c5bd94e40a8E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -34,49 +34,49 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3fmt3num50_$LT$impl$u20$core..fmt..Debug$u20$for$u20$i32$GT$3fmt17h57285fb3ede9d01cE"
+        "NormalSym": "_ZN4core3fmt3num50_$LT$impl$u20$core..fmt..Debug$u20$for$u20$i32$GT$3fmt17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN4core3fmt3num53_$LT$impl$u20$core..fmt..LowerHex$u20$for$u20$i32$GT$3fmt17h4a52d95dc4574769E"
+        "NormalSym": "_ZN4core3fmt3num53_$LT$impl$u20$core..fmt..LowerHex$u20$for$u20$i32$GT$3fmt17h"
       }
     ],
     [
       28,
       {
-        "NormalSym": "_ZN4core3fmt3num53_$LT$impl$u20$core..fmt..UpperHex$u20$for$u20$i32$GT$3fmt17hb461f3a25df6a443E"
+        "NormalSym": "_ZN4core3fmt3num53_$LT$impl$u20$core..fmt..UpperHex$u20$for$u20$i32$GT$3fmt17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core3fmt3num3imp52_$LT$impl$u20$core..fmt..Display$u20$for$u20$i32$GT$3fmt17h2f0986d8bc27bf03E"
+        "NormalSym": "_ZN4core3fmt3num3imp52_$LT$impl$u20$core..fmt..Display$u20$for$u20$i32$GT$3fmt17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hd98db8d17b807164E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       32,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17he87762546545c380E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       35,
       {
-        "NormalSym": "_ZN4core9panicking19assert_failed_inner17hae701ec8e1e0c738E"
+        "NormalSym": "_ZN4core9panicking19assert_failed_inner17h"
       }
     ],
     [
       41,
       {
-        "NormalSym": "_ZN4core9panicking13assert_failed17ha615b8109eb1d24eE"
+        "NormalSym": "_ZN4core9panicking13assert_failed17h"
       }
     ],
     [
@@ -457,7 +457,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hb9da34cecb7084feE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -820,7 +820,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17he87762546545c380E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1001,7 +1001,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he770fc9c7f092400E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1144,7 +1144,7 @@
           "name": "<&i32 as std::fmt::Debug>::fmt"
         }
       },
-      "symbol_name": "_ZN42_$LT$$RF$T$u20$as$u20$core..fmt..Debug$GT$3fmt17h83cea7bad7f3b5edE"
+      "symbol_name": "_ZN42_$LT$$RF$T$u20$as$u20$core..fmt..Debug$GT$3fmt17h"
     },
     {
       "details": null,
@@ -1666,7 +1666,7 @@
           "name": "core::fmt::num::<impl std::fmt::Debug for i32>::fmt"
         }
       },
-      "symbol_name": "_ZN4core3fmt3num50_$LT$impl$u20$core..fmt..Debug$u20$for$u20$i32$GT$3fmt17h57285fb3ede9d01cE"
+      "symbol_name": "_ZN4core3fmt3num50_$LT$impl$u20$core..fmt..Debug$u20$for$u20$i32$GT$3fmt17h"
     },
     {
       "details": null,
@@ -1753,7 +1753,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h4862a9441681ed9cE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1820,7 +1820,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h50b93c5bd94e40a8E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1979,7 +1979,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hd98db8d17b807164E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2018,7 +2018,7 @@
           "name": "std::ptr::drop_in_place::<&i32>"
         }
       },
-      "symbol_name": "_ZN4core3ptr28drop_in_place$LT$$RF$i32$GT$17h9641d331670bb7b5E"
+      "symbol_name": "_ZN4core3ptr28drop_in_place$LT$$RF$i32$GT$17h"
     },
     {
       "details": null,
@@ -2057,7 +2057,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h4c42ad109c7592a3E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2371,7 +2371,7 @@
           "name": "core::panicking::assert_failed::<i32, i32>"
         }
       },
-      "symbol_name": "_ZN4core9panicking13assert_failed17ha615b8109eb1d24eE"
+      "symbol_name": "_ZN4core9panicking13assert_failed17h"
     },
     {
       "details": null,
@@ -2467,7 +2467,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hb06ebd36cf1fd65bE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -3191,7 +3191,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN9assert_eq4main17hfc966d14489c115fE"
+      "symbol_name": "_ZN9assert_eq4main17h"
     }
   ]
 }

--- a/tests/integration/programs/binop.smir.json.expected
+++ b/tests/integration/programs/binop.smir.json.expected
@@ -1134,25 +1134,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he90aea535f4496f4E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h08eb118021a1dc92E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h58504e9a040c9e4dE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -1164,25 +1164,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17ha3ed128d842dfdf1E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h51ad69fdc370efa6E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       26,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
       31,
       {
-        "NormalSym": "_ZN5binop10test_binop17hbeddbf9d499fdbe1E"
+        "NormalSym": "_ZN5binop10test_binop17h"
       }
     ],
     [
@@ -1563,7 +1563,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h3ba479a87575e77fE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1926,7 +1926,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h51ad69fdc370efa6E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2107,7 +2107,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he90aea535f4496f4E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -2194,7 +2194,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h667ae919e9ab5bfcE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2261,7 +2261,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h58504e9a040c9e4dE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2420,7 +2420,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17ha3ed128d842dfdf1E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2459,7 +2459,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h458be6f014adabb4E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2555,7 +2555,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h08eb118021a1dc92E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -9540,7 +9540,7 @@
           "name": "test_binop"
         }
       },
-      "symbol_name": "_ZN5binop10test_binop17hbeddbf9d499fdbe1E"
+      "symbol_name": "_ZN5binop10test_binop17h"
     },
     {
       "details": null,
@@ -9776,7 +9776,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN5binop4main17h1be5589900968ba9E"
+      "symbol_name": "_ZN5binop4main17h"
     }
   ]
 }

--- a/tests/integration/programs/char-trivial.smir.json.expected
+++ b/tests/integration/programs/char-trivial.smir.json.expected
@@ -45,25 +45,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17ha21018ad4175866eE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hc064bca5f164541bE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h2404160337e74b25E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -75,19 +75,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h732125ae762d93e6E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hc79ad2be06c8228fE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       26,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -310,7 +310,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN12char_trivial4main17hdcdcf88dcae9eb46E"
+      "symbol_name": "_ZN12char_trivial4main17h"
     },
     {
       "details": null,
@@ -682,7 +682,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h96c2a96fcceb735fE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1045,7 +1045,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hc79ad2be06c8228fE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1226,7 +1226,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17ha21018ad4175866eE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1313,7 +1313,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17haf18f95177fe722cE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1380,7 +1380,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h2404160337e74b25E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1539,7 +1539,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h732125ae762d93e6E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1578,7 +1578,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17he0a0cc927472deb2E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1674,7 +1674,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hc064bca5f164541bE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/closure-args.smir.json.expected
+++ b/tests/integration/programs/closure-args.smir.json.expected
@@ -54,25 +54,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h0ea9521db3c84ccdE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hbf176849a7ced595E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hc3597144c5271f28E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -84,25 +84,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h0009d64ea9f5d8a8E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hef0fcd067a31abd9E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN12closure_args4main28_$u7b$$u7b$closure$u7d$$u7d$17h4010b117563766bdE"
+        "NormalSym": "_ZN12closure_args4main28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       26,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -420,7 +420,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN12closure_args4main17h2ed782b20238718aE"
+      "symbol_name": "_ZN12closure_args4main17h"
     },
     {
       "details": null,
@@ -604,7 +604,7 @@
           "name": "main::{closure#0}"
         }
       },
-      "symbol_name": "_ZN12closure_args4main28_$u7b$$u7b$closure$u7d$$u7d$17h4010b117563766bdE"
+      "symbol_name": "_ZN12closure_args4main28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -976,7 +976,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hec1fa9e4031ba742E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1339,7 +1339,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hef0fcd067a31abd9E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1520,7 +1520,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h0ea9521db3c84ccdE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1607,7 +1607,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hb6b071620dc68fc1E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1766,7 +1766,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h0009d64ea9f5d8a8E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1833,7 +1833,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hc3597144c5271f28E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1872,7 +1872,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17he3553ba4ad776982E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1968,7 +1968,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hbf176849a7ced595E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/closure-no-args.smir.json.expected
+++ b/tests/integration/programs/closure-no-args.smir.json.expected
@@ -48,25 +48,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17had87c6a7afa42371E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17haad8effff40ac51aE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h90d0d34e02ff3222E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -78,25 +78,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hdb736a5cb8fd8fdeE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h73fc191ccceb2237E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN15closure_no_args4main28_$u7b$$u7b$closure$u7d$$u7d$17hbfe1dbd09ae23abeE"
+        "NormalSym": "_ZN15closure_no_args4main28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       26,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -346,7 +346,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN15closure_no_args4main17hed04138a1eb95e9bE"
+      "symbol_name": "_ZN15closure_no_args4main17h"
     },
     {
       "details": null,
@@ -424,7 +424,7 @@
           "name": "main::{closure#0}"
         }
       },
-      "symbol_name": "_ZN15closure_no_args4main28_$u7b$$u7b$closure$u7d$$u7d$17hbfe1dbd09ae23abeE"
+      "symbol_name": "_ZN15closure_no_args4main28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -796,7 +796,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h69da4329aa000dccE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1159,7 +1159,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h73fc191ccceb2237E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1340,7 +1340,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17had87c6a7afa42371E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1427,7 +1427,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h3933dcebc964f0b2E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1494,7 +1494,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h90d0d34e02ff3222E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1653,7 +1653,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hdb736a5cb8fd8fdeE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1692,7 +1692,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h6a2a266b602ceb47E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1788,7 +1788,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17haad8effff40ac51aE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/const-arithm-simple.smir.json.expected
+++ b/tests/integration/programs/const-arithm-simple.smir.json.expected
@@ -38,25 +38,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hc220dca5a4a9c4e1E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hec1278d0bf08a55dE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h62435ed81bec6ce7E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -68,25 +68,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hdf7b2551e2c886aeE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h5e3c15d89ae15f10E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN19const_arithm_simple4test17h318cf5494f7e845bE"
+        "NormalSym": "_ZN19const_arithm_simple4test17h"
       }
     ],
     [
       28,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -463,7 +463,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN19const_arithm_simple4main17h7887b9190a80d762E"
+      "symbol_name": "_ZN19const_arithm_simple4main17h"
     },
     {
       "details": null,
@@ -567,7 +567,7 @@
           "name": "test"
         }
       },
-      "symbol_name": "_ZN19const_arithm_simple4test17h318cf5494f7e845bE"
+      "symbol_name": "_ZN19const_arithm_simple4test17h"
     },
     {
       "details": null,
@@ -939,7 +939,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hf4b87f91a0e3d576E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1302,7 +1302,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h5e3c15d89ae15f10E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1483,7 +1483,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hc220dca5a4a9c4e1E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1570,7 +1570,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17ha9f8925cafcca3adE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1637,7 +1637,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h62435ed81bec6ce7E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1796,7 +1796,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hdf7b2551e2c886aeE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1835,7 +1835,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17hde010ffffdc10138E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1931,7 +1931,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hec1278d0bf08a55dE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/div.smir.json.expected
+++ b/tests/integration/programs/div.smir.json.expected
@@ -51,25 +51,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h64d1191ef34b9bc1E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h7ed9fb0895a27f30E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hea7b7593e501aefeE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -81,19 +81,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hfade6072976a28f6E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h2993c2a6790fca01E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -677,7 +677,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN3div4main17h71fa6a28c244cb1fE"
+      "symbol_name": "_ZN3div4main17h"
     },
     {
       "details": null,
@@ -1049,7 +1049,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hcf20de394f35ad5dE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1412,7 +1412,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h2993c2a6790fca01E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1593,7 +1593,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h64d1191ef34b9bc1E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1680,7 +1680,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17he954194b4fcd00bfE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1747,7 +1747,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hea7b7593e501aefeE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1906,7 +1906,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hfade6072976a28f6E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1945,7 +1945,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h863a7b851113b2ceE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2041,7 +2041,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h7ed9fb0895a27f30E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/double-ref-deref.smir.json.expected
+++ b/tests/integration/programs/double-ref-deref.smir.json.expected
@@ -46,25 +46,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hf9d0cc1c3b14cd54E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h984a68eef244fa6eE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h537e81d3d052cbb1E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -76,19 +76,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hc6f736f3375605e4E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h4832dffd1cd541dcE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -428,7 +428,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN16double_ref_deref4main17h91fba97ff36c5fccE"
+      "symbol_name": "_ZN16double_ref_deref4main17h"
     },
     {
       "details": null,
@@ -800,7 +800,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h7879595fd7fe0ffbE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1163,7 +1163,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h4832dffd1cd541dcE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1344,7 +1344,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hf9d0cc1c3b14cd54E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1431,7 +1431,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h4d5385b298460ae7E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1498,7 +1498,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h537e81d3d052cbb1E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1657,7 +1657,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hc6f736f3375605e4E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1696,7 +1696,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h6899baa79b5d50c3E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1792,7 +1792,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h984a68eef244fa6eE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/enum.smir.json.expected
+++ b/tests/integration/programs/enum.smir.json.expected
@@ -4,25 +4,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he982f1804e60d9caE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h8d0dab3da83a2eb4E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17had7be3e3af3ffd6aE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -34,13 +34,13 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h65f703896e5e55f2E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h1cb035a01127d8feE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
@@ -421,7 +421,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17ha39a2a569a41c338E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -784,7 +784,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h1cb035a01127d8feE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -965,7 +965,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he982f1804e60d9caE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1052,7 +1052,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h0a5309ab9e4a463dE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1211,7 +1211,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h65f703896e5e55f2E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1278,7 +1278,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17had7be3e3af3ffd6aE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1317,7 +1317,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h8b89655b9ba64c0bE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1398,7 +1398,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN4enum4main17h578c4aafc4e87126E"
+      "symbol_name": "_ZN4enum4main17h"
     },
     {
       "details": null,
@@ -1494,7 +1494,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h8d0dab3da83a2eb4E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/fibonacci.smir.json.expected
+++ b/tests/integration/programs/fibonacci.smir.json.expected
@@ -45,25 +45,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h9592af04f080b6ddE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hdd617c230efb569eE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h3c3b44f3e5bc617eE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -75,25 +75,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h3510792785d7cbb1E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17he1dd627769ba43a1E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN9fibonacci9fibonacci17haf9f059a822166cdE"
+        "NormalSym": "_ZN9fibonacci9fibonacci17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -474,7 +474,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17ha7f92b0685306b3cE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -837,7 +837,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17he1dd627769ba43a1E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1018,7 +1018,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h9592af04f080b6ddE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1105,7 +1105,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h723634910b4137c7E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1264,7 +1264,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h3510792785d7cbb1E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1331,7 +1331,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h3c3b44f3e5bc617eE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1370,7 +1370,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h49212ee6f8ae9726E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1466,7 +1466,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hdd617c230efb569eE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -1676,7 +1676,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN9fibonacci4main17h84048a605568c1d4E"
+      "symbol_name": "_ZN9fibonacci4main17h"
     },
     {
       "details": null,
@@ -2349,7 +2349,7 @@
           "name": "fibonacci"
         }
       },
-      "symbol_name": "_ZN9fibonacci9fibonacci17haf9f059a822166cdE"
+      "symbol_name": "_ZN9fibonacci9fibonacci17h"
     }
   ]
 }

--- a/tests/integration/programs/float.smir.json.expected
+++ b/tests/integration/programs/float.smir.json.expected
@@ -93,25 +93,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hec1eb5b3a95108a0E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h13440d706a00baf7E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h24da6f29609285ddE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -123,19 +123,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17he234f85ee35f62efE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h4a15e8b61fa38dcdE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -516,7 +516,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17he1d7ccefaa6dc143E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -879,7 +879,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h4a15e8b61fa38dcdE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1060,7 +1060,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hec1eb5b3a95108a0E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1147,7 +1147,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h207239d44f06c48eE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1214,7 +1214,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h24da6f29609285ddE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1373,7 +1373,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17he234f85ee35f62efE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1412,7 +1412,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17ha117c841898d56b9E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1508,7 +1508,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h13440d706a00baf7E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2245,7 +2245,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN5float4main17hba1d3d01398882abE"
+      "symbol_name": "_ZN5float4main17h"
     }
   ]
 }

--- a/tests/integration/programs/modulo.smir.json.expected
+++ b/tests/integration/programs/modulo.smir.json.expected
@@ -49,25 +49,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h14e5f2504d96a2dfE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hab1f24d8faaecb52E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h979188c36192a753E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -79,19 +79,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17he4c05346bd0dcef9E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8ff1e9a30552c38eE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -472,7 +472,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h63a8340ba339b238E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -835,7 +835,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8ff1e9a30552c38eE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1016,7 +1016,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h14e5f2504d96a2dfE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1103,7 +1103,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hee1b6f635523a8d7E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1170,7 +1170,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h979188c36192a753E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1329,7 +1329,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17he4c05346bd0dcef9E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1368,7 +1368,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h08d58f5924f7e805E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1464,7 +1464,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hab1f24d8faaecb52E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2039,7 +2039,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN6modulo4main17h4106dafab6d6f113E"
+      "symbol_name": "_ZN6modulo4main17h"
     }
   ]
 }

--- a/tests/integration/programs/mutual_recursion.smir.json.expected
+++ b/tests/integration/programs/mutual_recursion.smir.json.expected
@@ -48,25 +48,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hcd52964f2ca312ddE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h53659d65e7692e7aE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hb5b0fba1c2de5389E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -78,31 +78,31 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h5c122f1a07159b22E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hdccbb66fb8dca376E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN16mutual_recursion6is_odd17h9569a7b059bb3702E"
+        "NormalSym": "_ZN16mutual_recursion6is_odd17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN16mutual_recursion7is_even17h4e35e0a16b0f3490E"
+        "NormalSym": "_ZN16mutual_recursion7is_even17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -321,7 +321,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN16mutual_recursion4main17h38e5604d644a3007E"
+      "symbol_name": "_ZN16mutual_recursion4main17h"
     },
     {
       "details": null,
@@ -630,7 +630,7 @@
           "name": "is_odd"
         }
       },
-      "symbol_name": "_ZN16mutual_recursion6is_odd17h9569a7b059bb3702E"
+      "symbol_name": "_ZN16mutual_recursion6is_odd17h"
     },
     {
       "details": null,
@@ -939,7 +939,7 @@
           "name": "is_even"
         }
       },
-      "symbol_name": "_ZN16mutual_recursion7is_even17h4e35e0a16b0f3490E"
+      "symbol_name": "_ZN16mutual_recursion7is_even17h"
     },
     {
       "details": null,
@@ -1311,7 +1311,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h1e192d77d7da5a04E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1674,7 +1674,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hdccbb66fb8dca376E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1855,7 +1855,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hcd52964f2ca312ddE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1942,7 +1942,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hbb5da079540ef856E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2101,7 +2101,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h5c122f1a07159b22E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2168,7 +2168,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hb5b0fba1c2de5389E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2207,7 +2207,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h9d4256942c1a76d1E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2303,7 +2303,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h53659d65e7692e7aE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/option-construction.smir.json.expected
+++ b/tests/integration/programs/option-construction.smir.json.expected
@@ -4,25 +4,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h925669b3e5c1558cE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h655b9b1e12bd730dE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h3f1b6c09e806e312E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -34,25 +34,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h55e32bb642146e02E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h3c05dfd176f9f27fE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core6option13unwrap_failed17h6055e3ba7a15ec00E"
+        "NormalSym": "_ZN4core6option13unwrap_failed17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core6option15Option$LT$T$GT$6unwrap17h1eccd13f6e05cb6fE"
+        "NormalSym": "_ZN4core6option15Option$LT$T$GT$6unwrap17h"
       }
     ],
     [
@@ -276,7 +276,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN19option_construction4main17h8a12528da185363eE"
+      "symbol_name": "_ZN19option_construction4main17h"
     },
     {
       "details": null,
@@ -648,7 +648,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17he6c404e6b502f630E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1011,7 +1011,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h3c05dfd176f9f27fE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1192,7 +1192,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h925669b3e5c1558cE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1279,7 +1279,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hcc1e21bb8a7447c4E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1346,7 +1346,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h3f1b6c09e806e312E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1505,7 +1505,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h55e32bb642146e02E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1544,7 +1544,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h322982812c073270E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1736,7 +1736,7 @@
           "name": "std::option::Option::<u32>::unwrap"
         }
       },
-      "symbol_name": "_ZN4core6option15Option$LT$T$GT$6unwrap17h1eccd13f6e05cb6fE"
+      "symbol_name": "_ZN4core6option15Option$LT$T$GT$6unwrap17h"
     },
     {
       "details": null,
@@ -1832,7 +1832,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h655b9b1e12bd730dE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/primitive-type-bounds.smir.json.expected
+++ b/tests/integration/programs/primitive-type-bounds.smir.json.expected
@@ -43,25 +43,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hef6c7380c3f06920E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hab588e4fe985e26cE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hc3299a837d16d788E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -73,19 +73,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17he67bf42a55cc3df7E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h35ee03377e0bbb80E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -540,7 +540,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN21primitive_type_bounds4main17h5c3af069c6dca662E"
+      "symbol_name": "_ZN21primitive_type_bounds4main17h"
     },
     {
       "details": null,
@@ -912,7 +912,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hd0873d35280532adE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1275,7 +1275,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h35ee03377e0bbb80E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1456,7 +1456,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hef6c7380c3f06920E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1543,7 +1543,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h65e7b8ea1d58c373E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1610,7 +1610,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hc3299a837d16d788E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1769,7 +1769,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17he67bf42a55cc3df7E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1808,7 +1808,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17ha011e9e2b70943a3E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1904,7 +1904,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hab588e4fe985e26cE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/recursion-simple-match.smir.json.expected
+++ b/tests/integration/programs/recursion-simple-match.smir.json.expected
@@ -46,25 +46,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he5540e8be59dc4e9E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h1b26615e5477064aE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h96c25281eded21e5E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -76,25 +76,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h5271de7d02e9edcaE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hc3cc7da138ab0f4eE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN22recursion_simple_match12sum_to_n_rec17h758e42f7af76951cE"
+        "NormalSym": "_ZN22recursion_simple_match12sum_to_n_rec17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -535,7 +535,7 @@
           "name": "sum_to_n_rec"
         }
       },
-      "symbol_name": "_ZN22recursion_simple_match12sum_to_n_rec17h758e42f7af76951cE"
+      "symbol_name": "_ZN22recursion_simple_match12sum_to_n_rec17h"
     },
     {
       "details": null,
@@ -745,7 +745,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN22recursion_simple_match4main17hcc84aa0b3c910002E"
+      "symbol_name": "_ZN22recursion_simple_match4main17h"
     },
     {
       "details": null,
@@ -1117,7 +1117,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h6027155185799025E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1480,7 +1480,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hc3cc7da138ab0f4eE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1661,7 +1661,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17he5540e8be59dc4e9E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1748,7 +1748,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h10fad7ae9de5e934E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1907,7 +1907,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h5271de7d02e9edcaE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1974,7 +1974,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h96c25281eded21e5E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2013,7 +2013,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17ha54d3e04cb1513d1E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2109,7 +2109,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h1b26615e5477064aE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/recursion-simple.smir.json.expected
+++ b/tests/integration/programs/recursion-simple.smir.json.expected
@@ -46,25 +46,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hc9ab170b11232827E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h655bbf5ad37d7866E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h47cc69539d774688E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -76,25 +76,25 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h2500d7ea93f58c70E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17he2c9997af6ea1a36E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN16recursion_simple12sum_to_n_rec17h3cbe6d03a5ef69a5E"
+        "NormalSym": "_ZN16recursion_simple12sum_to_n_rec17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -535,7 +535,7 @@
           "name": "sum_to_n_rec"
         }
       },
-      "symbol_name": "_ZN16recursion_simple12sum_to_n_rec17h3cbe6d03a5ef69a5E"
+      "symbol_name": "_ZN16recursion_simple12sum_to_n_rec17h"
     },
     {
       "details": null,
@@ -745,7 +745,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN16recursion_simple4main17hea083389f2add465E"
+      "symbol_name": "_ZN16recursion_simple4main17h"
     },
     {
       "details": null,
@@ -1117,7 +1117,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h6f3b8935440502e9E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1480,7 +1480,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17he2c9997af6ea1a36E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1661,7 +1661,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hc9ab170b11232827E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1748,7 +1748,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17ha99303762f727ffbE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1907,7 +1907,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h2500d7ea93f58c70E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1974,7 +1974,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h47cc69539d774688E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2013,7 +2013,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h5cd86cd7d05abed4E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2109,7 +2109,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h655bbf5ad37d7866E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/ref-deref.smir.json.expected
+++ b/tests/integration/programs/ref-deref.smir.json.expected
@@ -44,25 +44,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h2209da0d85019512E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h4f9c77724b045647E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h29c17b0395cce9dfE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -74,19 +74,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h8b71e772c69320b4E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h24aba19602c3173dE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -467,7 +467,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hff3c45a4441fa21cE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -830,7 +830,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h24aba19602c3173dE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1011,7 +1011,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h2209da0d85019512E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1098,7 +1098,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h354c1eede3be2001E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1165,7 +1165,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h29c17b0395cce9dfE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1324,7 +1324,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h8b71e772c69320b4E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1363,7 +1363,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h81f3fb8d0c7e4abeE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1459,7 +1459,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h4f9c77724b045647E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -1738,7 +1738,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN9ref_deref4main17hd5e9aa3e9b096520E"
+      "symbol_name": "_ZN9ref_deref4main17h"
     }
   ]
 }

--- a/tests/integration/programs/shl_min.smir.json.expected
+++ b/tests/integration/programs/shl_min.smir.json.expected
@@ -316,25 +316,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h380b4a51a57f858cE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hc22d5c4d8d5eda4dE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h5565a84b2bcc8422E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -346,19 +346,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h97a7ff3f152f48d5E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h1d02efcb48d20e88E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -739,7 +739,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h2f8fa9f18a134a32E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1102,7 +1102,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h1d02efcb48d20e88E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1283,7 +1283,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h380b4a51a57f858cE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1370,7 +1370,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h10dddd6d4fdde398E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1437,7 +1437,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h5565a84b2bcc8422E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1596,7 +1596,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h97a7ff3f152f48d5E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1635,7 +1635,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h3bd2945761e325daE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1731,7 +1731,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hc22d5c4d8d5eda4dE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -3522,7 +3522,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN7shl_min4main17ha09d7c732fcbfe55E"
+      "symbol_name": "_ZN7shl_min4main17h"
     }
   ]
 }

--- a/tests/integration/programs/slice.smir.json.expected
+++ b/tests/integration/programs/slice.smir.json.expected
@@ -70,37 +70,37 @@
     [
       1,
       {
-        "NormalSym": "_ZN4core5slice5index24slice_end_index_len_fail17h137110c15301da79E"
+        "NormalSym": "_ZN4core5slice5index24slice_end_index_len_fail17h"
       }
     ],
     [
       4,
       {
-        "NormalSym": "_ZN4core5slice5index22slice_index_order_fail17hff5113e5cc04c9f9E"
+        "NormalSym": "_ZN4core5slice5index22slice_index_order_fail17h"
       }
     ],
     [
       11,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       24,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h3c2d0d2dccd344b9E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hbea5f2636f8c0c63E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h3eae969071474082E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -112,37 +112,37 @@
     [
       32,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h311abd4b1c62697bE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       34,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hcc1384a9a6ecebd6E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       36,
       {
-        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17hf3bc4d3662561217E"
+        "NormalSym": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
       }
     ],
     [
       38,
       {
-        "NormalSym": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17haaa877014424f7ceE"
+        "NormalSym": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17h"
       }
     ],
     [
       43,
       {
-        "NormalSym": "_ZN4core5array8equality92_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u5d$$GT$2eq17h5f2ede35930746bbE"
+        "NormalSym": "_ZN4core5array8equality92_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u5d$$GT$2eq17h"
       }
     ],
     [
       45,
       {
-        "NormalSym": "_ZN106_$LT$core..ops..range..Range$LT$usize$GT$$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h5a835d09b00d32a5E"
+        "NormalSym": "_ZN106_$LT$core..ops..range..Range$LT$usize$GT$$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
       }
     ],
     [
@@ -154,19 +154,19 @@
     [
       47,
       {
-        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h898083967c05e5c7E"
+        "NormalSym": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
       }
     ],
     [
       48,
       {
-        "NormalSym": "_ZN4core5array8equality96_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$RF$$u5b$T$u5d$$GT$2eq17h20bda229d8d515edE"
+        "NormalSym": "_ZN4core5array8equality96_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$RF$$u5b$T$u5d$$GT$2eq17h"
       }
     ],
     [
       49,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -1058,7 +1058,7 @@
           "name": "<std::ops::Range<usize> as std::slice::SliceIndex<[i32]>>::index"
         }
       },
-      "symbol_name": "_ZN106_$LT$core..ops..range..Range$LT$usize$GT$$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h5a835d09b00d32a5E"
+      "symbol_name": "_ZN106_$LT$core..ops..range..Range$LT$usize$GT$$u20$as$u20$core..slice..index..SliceIndex$LT$$u5b$T$u5d$$GT$$GT$5index17h"
     },
     {
       "details": null,
@@ -1430,7 +1430,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h77bea8e7c7fcc35bE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1793,7 +1793,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hcc1384a9a6ecebd6E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1974,7 +1974,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h3c2d0d2dccd344b9E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -2061,7 +2061,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hb5e2594a7379e80eE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -2220,7 +2220,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h311abd4b1c62697bE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2287,7 +2287,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h3eae969071474082E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -2326,7 +2326,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17hfc048dbcd70f305eE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2473,7 +2473,7 @@
           "name": "std::array::<impl std::ops::Index<std::ops::Range<usize>> for [i32; 4]>::index"
         }
       },
-      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h898083967c05e5c7E"
+      "symbol_name": "_ZN4core5array85_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u3b$$u20$N$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -3168,7 +3168,7 @@
           "name": "std::array::equality::<impl std::cmp::PartialEq<[i32; 2]> for [i32]>::eq"
         }
       },
-      "symbol_name": "_ZN4core5array8equality92_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u5d$$GT$2eq17h5f2ede35930746bbE"
+      "symbol_name": "_ZN4core5array8equality92_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$u5b$T$u5d$$GT$2eq17h"
     },
     {
       "details": null,
@@ -3311,7 +3311,7 @@
           "name": "std::array::equality::<impl std::cmp::PartialEq<[i32; 2]> for &[i32]>::eq"
         }
       },
-      "symbol_name": "_ZN4core5array8equality96_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$RF$$u5b$T$u5d$$GT$2eq17h20bda229d8d515edE"
+      "symbol_name": "_ZN4core5array8equality96_$LT$impl$u20$core..cmp..PartialEq$LT$$u5b$U$u3b$$u20$N$u5d$$GT$$u20$for$u20$$RF$$u5b$T$u5d$$GT$2eq17h"
     },
     {
       "details": null,
@@ -3427,7 +3427,7 @@
           "name": "core::slice::index::<impl std::ops::Index<std::ops::Range<usize>> for [i32]>::index"
         }
       },
-      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17hf3bc4d3662561217E"
+      "symbol_name": "_ZN4core5slice5index74_$LT$impl$u20$core..ops..index..Index$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$5index17h"
     },
     {
       "details": null,
@@ -3523,7 +3523,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hbea5f2636f8c0c63E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -4254,7 +4254,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN5slice4main17h982023fdd0e6b27fE"
+      "symbol_name": "_ZN5slice4main17h"
     },
     {
       "details": null,
@@ -4412,7 +4412,7 @@
           "name": "<i32 as std::array::equality::SpecArrayEq<i32, 2>>::spec_eq"
         }
       },
-      "symbol_name": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17haaa877014424f7ceE"
+      "symbol_name": "_ZN69_$LT$T$u20$as$u20$core..array..equality..SpecArrayEq$LT$U$C$_$GT$$GT$7spec_eq17h"
     }
   ]
 }

--- a/tests/integration/programs/strange-ref-deref.smir.json.expected
+++ b/tests/integration/programs/strange-ref-deref.smir.json.expected
@@ -45,25 +45,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h4c6d892f65578af7E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h61ff3532f28130abE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h17e4c3cc9ad24e82E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -75,19 +75,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h491807954c4c1c5fE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0564249960183bdaE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -431,7 +431,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN17strange_ref_deref4main17ha5ed69bb326768b5E"
+      "symbol_name": "_ZN17strange_ref_deref4main17h"
     },
     {
       "details": null,
@@ -803,7 +803,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hc5c15f73999053e2E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1166,7 +1166,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0564249960183bdaE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1347,7 +1347,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h4c6d892f65578af7E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1434,7 +1434,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h3055c96acf021728E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1501,7 +1501,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h17e4c3cc9ad24e82E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1660,7 +1660,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h491807954c4c1c5fE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1699,7 +1699,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h363eb22d98edc8abE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1795,7 +1795,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h61ff3532f28130abE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }

--- a/tests/integration/programs/struct.smir.json.expected
+++ b/tests/integration/programs/struct.smir.json.expected
@@ -51,25 +51,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h0699d3b40d658af9E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h07b34746fe4a8e28E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hb0b46d751d94c51dE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -81,19 +81,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hc83a06bf843dd1dfE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h304cf6e5c6625a84E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -474,7 +474,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h6f5509323d95d619E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -837,7 +837,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h304cf6e5c6625a84E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1018,7 +1018,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h0699d3b40d658af9E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1105,7 +1105,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h28b985da3dd0601dE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1172,7 +1172,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hb0b46d751d94c51dE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1331,7 +1331,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hc83a06bf843dd1dfE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1370,7 +1370,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h3d358cb6450153bdE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1466,7 +1466,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h07b34746fe4a8e28E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -1940,7 +1940,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN6struct4main17h5c592763fb9dc6c3E"
+      "symbol_name": "_ZN6struct4main17h"
     }
   ]
 }

--- a/tests/integration/programs/sum-to-n.smir.json.expected
+++ b/tests/integration/programs/sum-to-n.smir.json.expected
@@ -43,25 +43,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hd35b85d5c0390cf1E"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hcb7fa696e1ada2eeE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h1c41a4289354ed9eE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -73,31 +73,31 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h91171ee1e758b4c8E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hbf65feaff4e3e97dE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       28,
       {
-        "NormalSym": "_ZN8sum_to_n8sum_to_n17h4938f719ae861d21E"
+        "NormalSym": "_ZN8sum_to_n8sum_to_n17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
       32,
       {
-        "NormalSym": "_ZN8sum_to_n13test_sum_to_n17h05511a3b7ab62339E"
+        "NormalSym": "_ZN8sum_to_n13test_sum_to_n17h"
       }
     ],
     [
@@ -478,7 +478,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17hbb5439d01d0d6fdfE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -841,7 +841,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17hbf65feaff4e3e97dE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1022,7 +1022,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17hd35b85d5c0390cf1E"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1109,7 +1109,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h70b1ea40c7b2e5b1E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1176,7 +1176,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h1c41a4289354ed9eE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1335,7 +1335,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h91171ee1e758b4c8E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1374,7 +1374,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17he09300336d269a83E"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1470,7 +1470,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17hcb7fa696e1ada2eeE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -1866,7 +1866,7 @@
           "name": "test_sum_to_n"
         }
       },
-      "symbol_name": "_ZN8sum_to_n13test_sum_to_n17h05511a3b7ab62339E"
+      "symbol_name": "_ZN8sum_to_n13test_sum_to_n17h"
     },
     {
       "details": null,
@@ -1933,7 +1933,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN8sum_to_n4main17h035b1be00fe7d484E"
+      "symbol_name": "_ZN8sum_to_n4main17h"
     },
     {
       "details": null,
@@ -2539,7 +2539,7 @@
           "name": "sum_to_n"
         }
       },
-      "symbol_name": "_ZN8sum_to_n8sum_to_n17h4938f719ae861d21E"
+      "symbol_name": "_ZN8sum_to_n8sum_to_n17h"
     }
   ]
 }

--- a/tests/integration/programs/tuple-eq.smir.json.expected
+++ b/tests/integration/programs/tuple-eq.smir.json.expected
@@ -74,25 +74,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h333150e68339170dE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h802a391040998644E"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hc8fe996961b168afE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -104,31 +104,31 @@
     [
       23,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h25f27f1fe7e893baE"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h79451430f217f4ecE"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       27,
       {
-        "NormalSym": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17ha183e644e33f34d8E"
+        "NormalSym": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17h"
       }
     ],
     [
       29,
       {
-        "NormalSym": "_ZN4core5tuple64_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$$LP$U$C$T$RP$$GT$2eq17h01cda7e1735747c8E"
+        "NormalSym": "_ZN4core5tuple64_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$$LP$U$C$T$RP$$GT$2eq17h"
       }
     ],
     [
       30,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -509,7 +509,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h4a8ff1f95d63fd82E"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -872,7 +872,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h79451430f217f4ecE"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1053,7 +1053,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h333150e68339170dE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1233,7 +1233,7 @@
           "name": "std::cmp::impls::<impl std::cmp::PartialEq for i32>::eq"
         }
       },
-      "symbol_name": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17ha183e644e33f34d8E"
+      "symbol_name": "_ZN4core3cmp5impls54_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$i32$GT$2eq17h"
     },
     {
       "details": null,
@@ -1320,7 +1320,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h485d9eaffc868729E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1479,7 +1479,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h25f27f1fe7e893baE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1546,7 +1546,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hc8fe996961b168afE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1585,7 +1585,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17ha00f3cf49702cdddE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -2050,7 +2050,7 @@
           "name": "core::tuple::<impl std::cmp::PartialEq for (i32, i32)>::eq"
         }
       },
-      "symbol_name": "_ZN4core5tuple64_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$$LP$U$C$T$RP$$GT$2eq17h01cda7e1735747c8E"
+      "symbol_name": "_ZN4core5tuple64_$LT$impl$u20$core..cmp..PartialEq$u20$for$u20$$LP$U$C$T$RP$$GT$2eq17h"
     },
     {
       "details": null,
@@ -2146,7 +2146,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h802a391040998644E"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     },
     {
       "details": null,
@@ -2616,7 +2616,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN8tuple_eq4main17ha65f20838f174f24E"
+      "symbol_name": "_ZN8tuple_eq4main17h"
     }
   ]
 }

--- a/tests/integration/programs/tuples-simple.smir.json.expected
+++ b/tests/integration/programs/tuples-simple.smir.json.expected
@@ -51,25 +51,25 @@
     [
       0,
       {
-        "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
+        "NormalSym": "_ZN3std2rt19lang_start_internal17h"
       }
     ],
     [
       13,
       {
-        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h00643f07709fa1eaE"
+        "NormalSym": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
       }
     ],
     [
       14,
       {
-        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h23382e62d2feae6bE"
+        "NormalSym": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
       }
     ],
     [
       19,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h0d9b04fb7ab9c1b6E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
@@ -81,19 +81,19 @@
     [
       21,
       {
-        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17hafce5092b1d3d3a9E"
+        "NormalSym": "_ZN4core3ops8function6FnOnce9call_once17h"
       }
     ],
     [
       23,
       {
-        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0a77e0c39c7e9e81E"
+        "NormalSym": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
       }
     ],
     [
       25,
       {
-        "NormalSym": "_ZN4core9panicking5panic17h1b078f0122adb34fE"
+        "NormalSym": "_ZN4core9panicking5panic17h"
       }
     ],
     [
@@ -422,7 +422,7 @@
           "name": "main"
         }
       },
-      "symbol_name": "_ZN13tuples_simple4main17hf563d963407a8479E"
+      "symbol_name": "_ZN13tuples_simple4main17h"
     },
     {
       "details": null,
@@ -794,7 +794,7 @@
           "name": "std::rt::lang_start::<()>"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start17h08d5ed836490d97bE"
+      "symbol_name": "_ZN3std2rt10lang_start17h"
     },
     {
       "details": null,
@@ -1157,7 +1157,7 @@
           "name": "std::rt::lang_start::<()>::{closure#0}"
         }
       },
-      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h0a77e0c39c7e9e81E"
+      "symbol_name": "_ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1338,7 +1338,7 @@
           "name": "std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>"
         }
       },
-      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h00643f07709fa1eaE"
+      "symbol_name": "_ZN3std3sys9backtrace28__rust_begin_short_backtrace17h"
     },
     {
       "details": null,
@@ -1425,7 +1425,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hf3797bbe895965bfE"
+      "symbol_name": "_ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17h"
     },
     {
       "details": null,
@@ -1492,7 +1492,7 @@
           "name": "<fn() as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h0d9b04fb7ab9c1b6E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1651,7 +1651,7 @@
           "name": "<{closure@std::rt::lang_start<()>::{closure#0}} as std::ops::FnOnce<()>>::call_once"
         }
       },
-      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hafce5092b1d3d3a9E"
+      "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h"
     },
     {
       "details": null,
@@ -1690,7 +1690,7 @@
           "name": "std::ptr::drop_in_place::<{closure@std::rt::lang_start<()>::{closure#0}}>"
         }
       },
-      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h55cd7ab616222eddE"
+      "symbol_name": "_ZN4core3ptr85drop_in_place$LT$std..rt..lang_start$LT$$LP$$RP$$GT$..$u7b$$u7b$closure$u7d$$u7d$$GT$17h"
     },
     {
       "details": null,
@@ -1786,7 +1786,7 @@
           "name": "<() as std::process::Termination>::report"
         }
       },
-      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h23382e62d2feae6bE"
+      "symbol_name": "_ZN54_$LT$$LP$$RP$$u20$as$u20$std..process..Termination$GT$6report17h"
     }
   ]
 }


### PR DESCRIPTION
This PR adds functionality to filter and normalise the json output when comparing output to the golden tests. Some cases when we want to normalise output:
1. `"NormalSym"` mangled function names will have a hash following `17h` that will [change when the compiler version changes](https://github.com/rust-lang/rust/blob/2ae9916816a448fcaab3b2da461de754eda0055a/compiler/rustc_symbol_mangling/src/lib.rs#L69-L76). 
```
<         "NormalSym": "_ZN3std2rt19lang_start_internal17h3166ab4c34d1da61E"
---
>         "NormalSym": "_ZN3std2rt19lang_start_internal17h51b943990c0e2c96E"
                                                        ^----can ignore---^
```
2. `"symbol_name"` mangled function names will have a hash following `17h` that will [change when the compiler version changes](https://github.com/rust-lang/rust/blob/2ae9916816a448fcaab3b2da461de754eda0055a/compiler/rustc_symbol_mangling/src/lib.rs#L69-L76). 
```
<       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17h40ba616aaa505a69E"
---
>       "symbol_name": "_ZN4core3ops8function6FnOnce9call_once17hd98db8d17b807164E"
```