### PR TITLE
Temporary fix for layout of panic strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -473,8 +473,33 @@ fn collect_arg_tys(collector: &mut InternedValueCollector, args: &stable_mir::ty
 }
 
 fn collect_ty(val_collector: &mut InternedValueCollector, val: stable_mir::ty::Ty) {
-    use stable_mir::ty::{RigidTy::*, TyKind::RigidTy}; // GenericArgKind::*, TyConst, TyConstKind::*
-    if val_collector.visited_tys.insert(hash(val), (val.kind(), val.layout().map(|l| l.shape()).ok())).is_some() {
+    use stable_mir::ty::{RigidTy::*, TyKind::RigidTy, AdtDef}; // GenericArgKind::*, TyConst, TyConstKind::*
+
+    // HACK: std::fmt::Arguments has escaping bounds and will error if trying to get the layout.
+    // We will just ban producing the layout for now see, this issue for more info
+    // https://github.com/runtimeverification/smir_pretty/issues/27
+    let maybe_layout = match val.kind() {
+      stable_mir::ty::TyKind::RigidTy(Adt(AdtDef(def_id_stable), _)) => {
+        let def_id_internal = rustc_internal::internal(val_collector.tcx, def_id_stable);
+        let name = rustc_middle::ty::print::with_no_trimmed_paths!(val_collector.tcx.def_path_str(def_id_internal));
+        if String::from("std::fmt::Arguments") == name {
+          None
+        } else {
+          Some(val.layout())
+        }
+      },
+      _ => {
+        Some(val.layout())
+      }
+    };
+    
+    let maybe_layout_shape = if let Some(Ok(layout)) = maybe_layout {
+      Some(layout.shape())
+    } else {
+      None
+    };
+
+    if val_collector.visited_tys.insert(hash(val), (val.kind(), maybe_layout_shape)).is_some() {
         match val.kind() {
             RigidTy(Array(ty, _) | Pat(ty, _) | Slice(ty) | RawPtr(ty, _) | Ref(_, ty, _)) => {
                 collect_ty(val_collector, ty)

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -473,7 +473,7 @@ fn collect_arg_tys(collector: &mut InternedValueCollector, args: &stable_mir::ty
 }
 
 fn collect_ty(val_collector: &mut InternedValueCollector, val: stable_mir::ty::Ty) {
-    use stable_mir::ty::{RigidTy::*, TyKind::RigidTy, AdtDef}; // GenericArgKind::*, TyConst, TyConstKind::*
+    use stable_mir::ty::{RigidTy::*, TyKind::RigidTy, AdtDef};
 
     // HACK: std::fmt::Arguments has escaping bounds and will error if trying to get the layout.
     // We will just ban producing the layout for now see, this issue for more info


### PR DESCRIPTION
Creating the layout for a `Binder<DUMMY>` is creating panics, see https://github.com/runtimeverification/smir_pretty/issues/27 for details. This PR does not solve the problem but side steps it. There may be other times that this will be needed unless we find a fix to get the `Layout` without triggering the error.