### PR TITLE
Makefile target to check failing tests and move to passing if successful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,22 @@ integration-test: build
 
 golden:
 	make integration-test DIFF=">"
+
+FAILING_DIR = $(CURDIR)/tests/integration/failing
+
+.PHONY: check-failing
+check-failing: SMIR      ?= $(CURDIR)/run.sh -Z no-codegen
+check-failing:
+	@mkdir -p $(TESTDIR) # Ensure passing directory exists
+	for rust in $(FAILING_DIR)/*.rs; do \
+		echo $${rust}; \
+		if ${SMIR} $${rust}; then \
+			target=$${rust%.rs}.smir.json.expected; \
+			mv $${rust} "$(TESTDIR)/"; \
+			mv $${target} "$(TESTDIR)/"; \
+			echo "Moved $${rust} to $(TESTDIR)/"; \
+			echo "Moved $${target} to $(TESTDIR)/"; \
+		else \
+			echo "Failed: $${rust} remains in $(FAILING_DIR)/"; \
+		fi \
+	done


### PR DESCRIPTION
This is not currently working, it does move the tests and the expected files, but it does not do the  comparison with the golden tests as it should - it just runs `./run.sh` and will always move the tests.