### PR TITLE
Option to generate a dot file representing the smir-json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,31 +3,37 @@
 version = 3
 
 [[package]]
-name = "once_cell"
-version = "1.19.0"
+name = "dot-writer"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "a2f7a508d3f95b7cb559acf2231c7efad02fe04061d3165b12513c2dbcc77af0"
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -36,14 +42,15 @@ dependencies = [
 name = "smir_pretty"
 version = "0.1.0"
 dependencies = [
+ "dot-writer",
  "tracing",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -63,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -74,15 +81,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dot-writer = "0.1.4"
 tracing = "0.1"
 # serde = { version = "=1.0.202", features = ["derive"] }
 # serde_cbor = "0.11"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ To generate stable MIR output without building a binary, you can invoke the tool
 ./run.sh -Z no-codegen <crate_root>
 ```
 
+There is experimental support for rendering the Stable-MIR items and their basic blocks as a 
+call graph in graphviz' dot format. 
+
+To produce a dot file `*.smir.dot` (instead of `*.smir.json`), one can invoke the driver with
+_first_ argument `--dot`. When using `--json` as the first argument, the `*.smir.json` file
+will be written. Any other strings given as first argument will be passed to the compiler 
+(like all subsequent arguments).
+
 There are a few environment variables that can be set to control the tools output:
 
 1.  `LINK_ITEMS` - add entries to the link-time `functions` map for each monomorphic item in the crate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private)]
 pub mod driver;
+pub mod mk_graph;
 pub mod printer;
 pub use driver::stable_mir_driver;
 pub use printer::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,23 @@ pub mod driver;
 pub mod printer;
 use driver::stable_mir_driver;
 use printer::emit_smir;
+use smir_pretty::mk_graph::emit_dotfile;
 
 fn main() {
-    let args: Vec<_> = env::args().collect();
-    stable_mir_driver(&args, emit_smir)
+    let mut args: Vec<String> = env::args().collect();
+
+    match args.get(1) {
+        None =>
+            stable_mir_driver(&args, emit_smir), // backward compatibility
+        Some(arg) if arg == "--json" => {
+            args.remove(1);
+            stable_mir_driver(  &args, emit_smir)
+        }
+        Some(arg) if arg == "--dot" => {
+            args.remove(1);
+            stable_mir_driver(&args, emit_dotfile)
+        }
+        Some(_other) =>
+            stable_mir_driver(&args, emit_smir), // backward compatibility
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
             stable_mir_driver(&args, emit_smir), // backward compatibility
         Some(arg) if arg == "--json" => {
             args.remove(1);
-            stable_mir_driver(  &args, emit_smir)
+            stable_mir_driver(&args, emit_smir)
         }
         Some(arg) if arg == "--dot" => {
             args.remove(1);

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -109,7 +109,11 @@ impl SmirJson<'_> {
                       .edge(&this_block, block_name(name, t))
                       .attributes()
                       .set_label(&format!("{d}"));
-                  }
+                  };
+                  cluster
+                    .edge(&this_block, block_name(name, targets.otherwise()))
+                    .attributes()
+                    .set_label("other");
                 },
                 Resume{} => {
                   n.set_label("Resume"); 

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -152,8 +152,8 @@ impl SmirJson<'_> {
                       .set_label(&dest);
                   }
 
-                  // The call edge has to be drawn outside the cluster, and therefore outside this function!
-                  // I have to separate this code into its own second function.
+                  // The call edge has to be drawn outside the cluster, outside this function (cluster borrows &mut graph)!
+                  // Code for that is therefore separated into its own second function below.
                 },
                 Assert{target, ..} => {
                   n.set_label("Assert");
@@ -216,16 +216,13 @@ impl SmirJson<'_> {
                     let e = match func {
                       Operand::Constant(ConstOperand{const_, ..}) => {
                         if let Some(callee) = func_map.get(&const_.ty()) {
-                          // if ! item_names.contains(callee) {
-                          //   graph
-                          //     .node_named(block_name(callee, 0))
-                          //     .set_label(callee);
-                          // }
+                          // callee node/body will be added when its body is added, missing ones added before
                           graph
                             .edge(&this_block, block_name(callee, 0))
                         } else {
                           let unknown = format!("{}", const_.ty());
-                          // graph.node_named(&unknown);
+                          // pathological case, could panic! instead.
+                          // all unknown callees will be collapsed into one `unknown` node
                           graph
                             .edge(&this_block, unknown)
                         }

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -89,7 +89,6 @@ impl SmirJson<'_> {
             // Cannot define local functions that capture env. variables. Instead we define _closures_.
             let process_block = |cluster:&mut Scope<'_,'_>, node_id: usize, b: &BasicBlock | {
               let name = &item.symbol_name;
-            //fn process_block<'a,'b>(name: &String, cluster:&mut Scope<'a,'b>, node_id: usize, b: &BasicBlock) {
               let this_block = block_name(name, node_id);
               let mut n = cluster.node_named(&this_block);
               // TODO: render statements and terminator as text label (with line breaks)

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -98,7 +98,7 @@ impl SmirJson<'_> {
 
                 Goto{target} => {
                   n.set_label("Goto");
-                  drop(n); // so we can borro `cluster` again below
+                  drop(n); // so we can borrow `cluster` again below
                   cluster.edge(&this_block, block_name(name, *target));
                 },
                 SwitchInt{discr:_, targets} => {

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -1,8 +1,13 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::{collections::HashMap, hash::{DefaultHasher, Hash, Hasher}};
 
-use crate::printer::{SmirJson};
+extern crate stable_mir;
 
-use dot_writer::{Color, DotWriter, Attributes, Shape, Style};
+use stable_mir::ty::Ty;
+use stable_mir::mir::{BasicBlock, Statement, TerminatorKind};
+
+use crate::{printer::{FnSymType, SmirJson}, MonoItemKind};
+
+use dot_writer::{DotWriter, Attributes, Scope};
 
 impl SmirJson<'_> {
 
@@ -14,22 +19,105 @@ impl SmirJson<'_> {
 
       writer.set_pretty_print(true);
 
-      writer.digraph().set_label(&self.name[..]);
+      let mut graph = writer.digraph();
+      graph.set_label(&self.name[..]);
+
+      let func_map: HashMap<Ty, String> = 
+        self.functions
+          .into_iter()
+          .map(|(k,v)| (k.0, mk_string(v)))
+          .collect();
+
+      for item in self.items {
+        match item.mono_item_kind {
+          MonoItemKind::MonoItemFn{ name, body, id: _} => {
+            let mut c = graph.cluster();
+            c.set_label(&name[..]);
+
+            fn process_block<'a,'b>(name: &String, cluster:&mut Scope<'a,'b>, node_id: usize, b: &BasicBlock) {
+              let mut n = cluster.node_named(block_name(name, node_id));
+              // TODO: render statements and terminator as text label (with line breaks)
+              n.set_label("the Terminator");
+              // switch on terminator kind, add inner and out-edges according to terminator
+              use TerminatorKind::*;
+              match b.terminator.kind {
+
+                Goto{target: _} => {},
+                SwitchInt{discr:_, targets: _} => {},
+                Resume{} => {},
+                Abort{} => {},
+                Return{} => {},
+                Unreachable{} => {},
+                TerminatorKind::Drop{place: _, target: _, unwind: _} => {},
+                Call{func: _, args: _, destination: _, target: _, unwind: _} => {},
+                Assert{target: _, ..} => {},
+                InlineAsm{destination: _, ..} => {}
+              }
+            }
+
+            fn process_blocks<'a,'b>(name: &String, cluster:&mut Scope<'a,'b>, offset: usize, blocks: &Vec<BasicBlock>) {
+              let mut n = offset;
+              for b in blocks {
+                process_block(name, cluster, n, b);
+                n += 1;
+              }
+            }
+
+
+            match body.len() {
+              0 => {
+                c.node_auto().set_label("<empty body>");
+              },
+              1 => {
+                process_blocks(&item.symbol_name, &mut c, 0, &body[0].blocks);
+              }
+              _more => {
+                let mut curr: usize = 0;
+                for b in body {
+                  let mut cc = c.cluster();
+                  process_blocks(&item.symbol_name, &mut cc, curr, &b.blocks);
+                  curr += b.blocks.len();
+                }
+              }
+            }
+
+          }
+          MonoItemKind::MonoItemGlobalAsm { asm } => {
+            let mut n = graph.node_named(short_name(&asm));
+            n.set_label(&asm.lines().collect::<String>()[..]);
+          }
+          MonoItemKind::MonoItemStatic { name, id: _, allocation: _ } => {
+            let mut n = graph.node_named(short_name(&name));
+            n.set_label(&name[..]);
+          }
+        }
+
+      }
+
     }
 
     String::from_utf8(bytes).expect("Error converting dot file")
   }
 
 }
+
+fn mk_string(f: FnSymType) -> String {
+  match f {
+    FnSymType::NormalSym(name) => name,
+    FnSymType::NoOpSym(name) => format!("NoOp: {name}"),
+    FnSymType::IntrinsicSym(name) => format!("Intr: {name}"),
+  }
+}
+
 /// consistently naming function clusters
-fn short_name(function_name: String) -> String {
+fn short_name(function_name: &String) -> String {
   let mut h = DefaultHasher::new();
   function_name.hash(&mut h);
   format!("X{:x}", h.finish())
 }
 
 /// consistently naming block nodes in function clusters
-fn block_name(function_name: String, id: usize) -> String {
+fn block_name(function_name: &String, id: usize) -> String {
   let mut h = DefaultHasher::new();
   function_name.hash(&mut h);
   format!("X{:x}_{}", h.finish(), id)

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -71,7 +71,7 @@ impl SmirJson<'_> {
         if ! item_names.contains(f) {
           graph
             .node_named(block_name(f, 0))
-            .set_label(f)
+            .set_label(&name_lines(f))
             .set_color(Color::Red);
         }
       }
@@ -80,7 +80,7 @@ impl SmirJson<'_> {
         match item.mono_item_kind {
           MonoItemKind::MonoItemFn{ name, body, id: _} => {
             let mut c = graph.cluster();
-            c.set_label(&name[..]);
+            c.set_label(&name_lines(&name));
 
             // Cannot define local functions that capture env. variables. Instead we define _closures_.
             let process_block = |cluster:&mut Scope<'_,'_>, node_id: usize, b: &BasicBlock | {
@@ -297,6 +297,15 @@ fn function_string(f: FnSymType) -> String {
     FnSymType::NoOpSym(name) => format!("NoOp: {name}"),
     FnSymType::IntrinsicSym(name) => format!("Intr: {name}"),
   }
+}
+
+fn name_lines(name: &String) -> String {
+  name
+    .split_inclusive(" ")
+    .flat_map(|s| s.split_inclusive("::"))
+    .map(|s| s.to_string())
+    .collect::<Vec<String>>()
+    .join("\\n")
 }
 
 /// consistently naming function clusters

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -1,0 +1,70 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use crate::printer::{SmirJson};
+
+use dot_writer::{Color, DotWriter, Attributes, Shape, Style};
+
+impl SmirJson<'_> {
+
+  pub fn to_dot_file(self) -> String {
+    let mut bytes = Vec::new();
+
+    { 
+      let mut writer = DotWriter::from(&mut bytes);
+
+      writer.set_pretty_print(true);
+
+      writer.digraph().set_label(&self.name[..]);
+    }
+
+    String::from_utf8(bytes).expect("Error converting dot file")
+  }
+
+}
+/// consistently naming function clusters
+fn short_name(function_name: String) -> String {
+  let mut h = DefaultHasher::new();
+  function_name.hash(&mut h);
+  format!("X{:x}", h.finish())
+}
+
+/// consistently naming block nodes in function clusters
+fn block_name(function_name: String, id: usize) -> String {
+  let mut h = DefaultHasher::new();
+  function_name.hash(&mut h);
+  format!("X{:x}_{}", h.finish(), id)
+}
+
+
+#[test]
+fn test_graphviz() {
+
+  use std::io;
+
+  let name = "fubar";
+
+  let mut w = io::stdout();
+
+  let mut writer: DotWriter = DotWriter::from(&mut w);
+
+  writer.set_pretty_print(true);
+
+  let mut digraph = writer.digraph();
+  
+  digraph
+    .node_attributes()
+    .set_shape(Shape::Rectangle)
+    .set_label(name);
+
+  digraph.node_auto().set_label(name);
+
+  let mut cluster = digraph.cluster();
+
+  cluster
+    .set_label("cluck cluck")
+    .set_color(Color::Blue);
+  cluster.node_named(short_name("cluck_1".to_string()));
+  cluster.node_named(block_name("cluck_2".to_string(), 2));
+  cluster.edge(short_name("cluck_1".to_string()), block_name("cluck_2".to_string(), 2));
+
+}

--- a/src/mk_graph.rs
+++ b/src/mk_graph.rs
@@ -1,6 +1,6 @@
 use std::{collections::{HashMap, HashSet}, fs::File, hash::{DefaultHasher, Hash, Hasher}, io::{self, Write}};
 
-use dot_writer::{Attributes, Color, DotWriter, Scope};
+use dot_writer::{Attributes, Color, DotWriter, Scope, Style};
 
 extern crate rustc_middle;
 use rustc_middle::ty::TyCtxt;
@@ -81,6 +81,10 @@ impl SmirJson<'_> {
           MonoItemKind::MonoItemFn{ name, body, id: _} => {
             let mut c = graph.cluster();
             c.set_label(&name_lines(&name));
+            if is_unqualified(&name) {
+              c.set_style(Style::Filled);
+              c.set_color(Color::LightGrey);
+            }
 
             // Cannot define local functions that capture env. variables. Instead we define _closures_.
             let process_block = |cluster:&mut Scope<'_,'_>, node_id: usize, b: &BasicBlock | {
@@ -289,6 +293,10 @@ fn show_op(op: &Operand) -> String {
 
 fn show_place(p: &Place) -> String {
   format!("_{}{}", p.local, if p.projection.len() > 0 { "(...)"} else {""})
+}
+
+fn is_unqualified(name: &String) -> bool {
+  ! name.contains("::")
 }
 
 fn function_string(f: FnSymType) -> String {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -765,11 +765,6 @@ pub fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
       let fn_sources =
         calls_map.clone().into_iter().map(|(k,(source,_))| (k,source)).collect::<Vec<_>>();
       Some(SmirJsonDebugInfo { fn_sources, types: visited_tys, foreign_modules: get_foreign_module_details()})
-    // write!(writer, "{{ \"fn_sources\": {}, \"types\": {}, \"foreign_modules\": {}}}",
-    //   serde_json::to_string(&fn_sources).expect("serde_json functions failed"),
-    //   serde_json::to_string(&visited_tys).expect("serde_json tys failed"),
-    //   serde_json::to_string(&get_foreign_module_details()).expect("foreign_module serialization failed"),
-    // ).expect("Failed to write JSON to file");
     } else {
       None
     };

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -739,7 +739,7 @@ pub struct SmirJsonDebugInfo<'t> {
 // Serialization Entrypoint
 // ========================
 
-fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
+pub fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
   let local_crate = stable_mir::local_crate();
   let items = collect_items(tcx);
   let items_clone = items.clone();

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::{TyCtxt, Ty, TyKind, EarlyBinder, FnSig, GenericArgs, Type
 use rustc_session::config::{OutFileName, OutputType};
 use rustc_span::{def_id::{DefId, LOCAL_CRATE}, symbol};
 use rustc_smir::rustc_internal;
-use stable_mir::{ 
+use stable_mir::{
   CrateItem,
   CrateDef,
   ItemKind,
@@ -493,7 +493,7 @@ fn collect_ty(val_collector: &mut InternedValueCollector, val: stable_mir::ty::T
         Some(val.layout())
       }
     };
-    
+
     let maybe_layout_shape = if let Some(Ok(layout)) = maybe_layout {
       Some(layout.shape())
     } else {
@@ -743,8 +743,10 @@ fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
   let local_crate = stable_mir::local_crate();
   let items = collect_items(tcx);
   let items_clone = items.clone();
-  let (unevaluated_consts, mut items) = collect_unevaluated_constant_items(tcx, items);
-  let (calls_map, visited_allocs, visited_tys) = collect_interned_values(tcx, items.iter().map(|i| &i.mono_item).collect::<Vec<_>>());
+  let (unevaluated_consts, mut items) =
+    collect_unevaluated_constant_items(tcx, items);
+  let (calls_map, visited_allocs, visited_tys) =
+    collect_interned_values(tcx, items.iter().map(|i| &i.mono_item).collect::<Vec<_>>());
 
   // FIXME: We dump extra static items here --- this should be handled better
   for (_, alloc) in visited_allocs.iter() {
@@ -758,10 +760,10 @@ fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
       }
   }
 
-  let calls_clone = calls_map.clone();
   let debug: Option<SmirJsonDebugInfo> =
     if debug_enabled() {
-      let fn_sources = calls_clone.into_iter().map(|(k,(source,_))| (k,source)).collect::<Vec<_>>();
+      let fn_sources =
+        calls_map.clone().into_iter().map(|(k,(source,_))| (k,source)).collect::<Vec<_>>();
       Some(SmirJsonDebugInfo { fn_sources, types: visited_tys, foreign_modules: get_foreign_module_details()})
     // write!(writer, "{{ \"fn_sources\": {}, \"types\": {}, \"foreign_modules\": {}}}",
     //   serde_json::to_string(&fn_sources).expect("serde_json functions failed"),
@@ -772,9 +774,12 @@ fn collect_smir(tcx: TyCtxt<'_>) -> SmirJson {
       None
     };
 
-  let called_functions = calls_map.into_iter().map(|(k,(_,name))| (k,name)).collect::<Vec<_>>();
-  let allocs = visited_allocs.into_iter().collect::<Vec<_>>();
-  let crate_id = tcx.stable_crate_id(LOCAL_CRATE).as_u64();
+  let called_functions =
+    calls_map.into_iter().map(|(k,(_,name))| (k,name)).collect::<Vec<_>>();
+  let allocs =
+    visited_allocs.into_iter().collect::<Vec<_>>();
+  let crate_id =
+    tcx.stable_crate_id(LOCAL_CRATE).as_u64();
 
   SmirJson {
     name: local_crate.name,
@@ -793,9 +798,14 @@ pub fn emit_smir(tcx: TyCtxt<'_>) {
   let smir_json = serde_json::to_string(&collect_smir(tcx)).expect("serde_json failed to write result");
 
   match tcx.output_filenames(()).path(OutputType::Mir) {
-    OutFileName::Stdout => { write!(&io::stdout(), "{}", smir_json).expect("Failed to write smir.json"); }
+    OutFileName::Stdout => {
+      write!(&io::stdout(), "{}", smir_json).expect("Failed to write smir.json");
+    }
     OutFileName::Real(path) => {
-      let mut b = io::BufWriter::new(File::create(&path.with_extension("smir.json")).expect("Failed to create {path}.smir.json output file"));
+      let mut b =
+        io::BufWriter::new(
+          File::create(&path.with_extension("smir.json"))
+            .expect("Failed to create {path}.smir.json output file"));
       write!(b, "{}", smir_json).expect("Failed to write smir.json");
     }
   }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -720,13 +720,13 @@ fn collect_items(tcx: TyCtxt<'_>) -> HashMap<String, Item> {
 /// the serialised data structure as a whole
 #[derive(Serialize)]
 pub struct SmirJson<'t> {
-  name: String,
-  crate_id: u64,
-  allocs: Vec<(AllocId,AllocInfo)>,
-  functions: Vec<(LinkMapKey<'t>, FnSymType)>,
-  uneval_consts: Vec<(ConstDef, String)>,
-  items: Vec<Item>,
-  debug: Option<SmirJsonDebugInfo<'t>>
+  pub name: String,
+  pub crate_id: u64,
+  pub allocs: Vec<(AllocId,AllocInfo)>,
+  pub functions: Vec<(LinkMapKey<'t>, FnSymType)>,
+  pub uneval_consts: Vec<(ConstDef, String)>,
+  pub items: Vec<Item>,
+  pub debug: Option<SmirJsonDebugInfo<'t>>
 }
 
 #[derive(Serialize)]

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -226,7 +226,7 @@ fn hash<T: std::hash::Hash>(obj: T) -> u64 {
 // =========================================================
 
 #[derive(Serialize, Clone)]
-enum MonoItemKind {
+pub enum MonoItemKind {
     MonoItemFn {
       name: String,
       id: stable_mir::DefId,
@@ -242,11 +242,11 @@ enum MonoItemKind {
     },
 }
 #[derive(Serialize, Clone)]
-struct Item {
+pub struct Item {
     #[serde(skip)]
     mono_item: MonoItem,
-    symbol_name: String,
-    mono_item_kind: MonoItemKind,
+    pub symbol_name: String,
+    pub mono_item_kind: MonoItemKind,
     details: Option<ItemDetails>,
 }
 
@@ -300,7 +300,7 @@ fn mk_item(tcx: TyCtxt<'_>, item: MonoItem, sym_name: String) -> Item {
 // ==========================
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-enum FnSymType {
+pub enum FnSymType {
     NoOpSym(String),
     IntrinsicSym(String),
     NormalSym(String),
@@ -330,7 +330,7 @@ fn fn_inst_sym<'tcx>(tcx: TyCtxt<'tcx>, ty: Option<stable_mir::ty::Ty>, inst: Op
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct LinkMapKey<'tcx>(stable_mir::ty::Ty, Option<middle::ty::InstanceKind<'tcx>>);
+pub struct LinkMapKey<'tcx>(pub stable_mir::ty::Ty, Option<middle::ty::InstanceKind<'tcx>>);
 
 impl Serialize for LinkMapKey<'_> {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -730,7 +730,7 @@ pub struct SmirJson<'t> {
 }
 
 #[derive(Serialize)]
-struct SmirJsonDebugInfo<'t> {
+pub struct SmirJsonDebugInfo<'t> {
   fn_sources: Vec<(LinkMapKey<'t>,ItemSource)>,
   types: TyMap,
   foreign_modules: Vec<(String, Vec<ForeignModule>)>


### PR DESCRIPTION
In this first version we don't draw the statements of blocks, just the block structure and caller/callee relations between blocks/items.

In terms of interface, the `main` program now has options `--json` and `--dot` which have to come first, and we default to `--json` if they are absent.

Output example: (main calls `foo(0)` calls `bar(0)`)
![image](https://github.com/user-attachments/assets/114bb9cb-e21a-4fd2-af4a-e2f8f0c87c1c)

The HS version had more color but was otherwise the same:
![image](https://github.com/user-attachments/assets/c391e9a7-4129-4702-a3c2-feb8a896ed78)

